### PR TITLE
0.4.x transition lattice tests

### DIFF
--- a/lib-py/casmutils/xtal/_xtal/lattice-py.hpp
+++ b/lib-py/casmutils/xtal/_xtal/lattice-py.hpp
@@ -5,7 +5,7 @@
 
 namespace rewrap
 {
-    class Lattice;
+class Lattice;
 }
 
 namespace wrappy
@@ -15,6 +15,5 @@ namespace Lattice
 std::string __str__(const rewrap::Lattice& printable);
 } // namespace Lattice
 } // namespace wrappy
-
 
 #endif

--- a/lib-py/casmutils/xtal/_xtal/rocksalttoggler-py.hpp
+++ b/lib-py/casmutils/xtal/_xtal/rocksalttoggler-py.hpp
@@ -5,7 +5,7 @@
 
 namespace enumeration
 {
-    class RockSaltOctahedraToggler;
+class RockSaltOctahedraToggler;
 }
 
 namespace wrappy

--- a/lib-py/casmutils/xtal/_xtal/site-py.hpp
+++ b/lib-py/casmutils/xtal/_xtal/site-py.hpp
@@ -1,11 +1,11 @@
 #ifndef SITE_PY_HH
 #define SITE_PY_HH
 
-#include<string>
+#include <string>
 
 namespace rewrap
 {
-    class Site;
+class Site;
 }
 
 namespace wrappy

--- a/lib-py/casmutils/xtal/_xtal/structure-py.hpp
+++ b/lib-py/casmutils/xtal/_xtal/structure-py.hpp
@@ -5,9 +5,9 @@
 
 namespace rewrap
 {
-    class Structure;
-    class Lattice;
-}
+class Structure;
+class Lattice;
+} // namespace rewrap
 
 namespace wrappy
 {

--- a/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
+++ b/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
@@ -1,12 +1,12 @@
 #include "./coordinate-py.hpp"
-#include "./site-py.hpp"
 #include "./lattice-py.hpp"
-#include "./structure-py.hpp"
 #include "./rocksalttoggler-py.hpp"
+#include "./site-py.hpp"
+#include "./structure-py.hpp"
 
-#include <casmutils/xtal/structure.hpp>
 #include <casmutils/xtal/coordinate.hpp>
 #include <casmutils/xtal/rocksalttoggler.hpp>
+#include <casmutils/xtal/structure.hpp>
 #include <casmutils/xtal/structure_tools.hpp>
 #include <fstream>
 #include <string>

--- a/tests/unit/casmutils/lattice.cpp
+++ b/tests/unit/casmutils/lattice.cpp
@@ -1,4 +1,65 @@
+#include <casmutils/xtal/lattice.hpp>
 #include <gtest/gtest.h>
+#include <memory>
+
+class LatticeTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        Eigen::Matrix3d fcc_matrix;
+		fcc_matrix <<0.0, 1.5, 1.5,
+					1.5, 0.0, 1.5,
+					1.5, 1.5, 0.0;
+        fcc_ptr.reset(new rewrap::Lattice(fcc_matrix));
+        fcc2_ptr.reset(new rewrap::Lattice(fcc_matrix));
+        Eigen::Matrix3d bcc_matrix;
+		bcc_matrix <<-1.5, 1.5, 1.5,
+					1.5, -1.5, 1.5,
+					1.5, 1.5, -1.5;
+        bcc_ptr.reset(new rewrap::Lattice(bcc_matrix));
+        Eigen::Matrix3d hcp_matrix;
+		hcp_matrix <<-2.871, -1.4355, 0.0,
+					0.0, 2.486358934265, 0.0,
+					0.0, 0.0, 4.635;
+        hcp_ptr.reset(new rewrap::Lattice(hcp_matrix));
+    }
+
+    // Use unique pointers because Lattice has no default constructor
+    std::unique_ptr<rewrap::Lattice> fcc_ptr;
+    std::unique_ptr<rewrap::Lattice> fcc2_ptr;
+    std::unique_ptr<rewrap::Lattice> bcc_ptr;
+    std::unique_ptr<rewrap::Lattice> hcp_ptr;
+};
+
+
+TEST_F(LatticeTest, ConstructandGetMatrix) { 
+	// This test constructs two different objects with the same matrix
+	// This test examines the functionality of the constructor and 
+	// column_vector_matrix()
+	EXPECT_EQ(fcc_ptr->column_vector_matrix(),
+		fcc2_ptr->column_vector_matrix());
+}
+
+TEST_F(LatticeTest, BracketOperator) { 
+	//This test uses the bracket operator to check that the
+	//third vector of z oriented hcp is along the z direction
+	auto unitvec=(*hcp_ptr)[2]/(*hcp_ptr)[2].norm();
+	EXPECT_EQ(unitvec,
+		Eigen::Vector3d(0,0,1));
+}
+
+TEST_F(LatticeTest, VectorAccess) { 
+	// This test grabs the vectors of a bcc lattice and sees that 
+	// the lengths are the same. Does the same for a and b of hcp
+	// tests a(), b(), c() 
+	EXPECT_EQ(bcc_ptr->a().norm(),
+			  bcc_ptr->b().norm());
+	EXPECT_EQ(bcc_ptr->a().norm(),
+			  bcc_ptr->c().norm());
+	EXPECT_EQ((hcp_ptr->a().norm()-
+			  hcp_ptr->b().norm())<1e-5,true);
+}
 
 int main(int argc, char** argv)
 {

--- a/tests/unit/casmutils/lattice.cpp
+++ b/tests/unit/casmutils/lattice.cpp
@@ -8,20 +8,14 @@ protected:
     void SetUp() override
     {
         Eigen::Matrix3d fcc_matrix;
-		fcc_matrix <<0.0, 1.5, 1.5,
-					1.5, 0.0, 1.5,
-					1.5, 1.5, 0.0;
+        fcc_matrix << 0.0, 1.5, 1.5, 1.5, 0.0, 1.5, 1.5, 1.5, 0.0;
         fcc_ptr.reset(new rewrap::Lattice(fcc_matrix));
         fcc2_ptr.reset(new rewrap::Lattice(fcc_matrix));
         Eigen::Matrix3d bcc_matrix;
-		bcc_matrix <<-1.5, 1.5, 1.5,
-					1.5, -1.5, 1.5,
-					1.5, 1.5, -1.5;
+        bcc_matrix << -1.5, 1.5, 1.5, 1.5, -1.5, 1.5, 1.5, 1.5, -1.5;
         bcc_ptr.reset(new rewrap::Lattice(bcc_matrix));
         Eigen::Matrix3d hcp_matrix;
-		hcp_matrix <<-2.871, -1.4355, 0.0,
-					0.0, 2.486358934265, 0.0,
-					0.0, 0.0, 4.635;
+        hcp_matrix << -2.871, -1.4355, 0.0, 0.0, 2.486358934265, 0.0, 0.0, 0.0, 4.635;
         hcp_ptr.reset(new rewrap::Lattice(hcp_matrix));
     }
 
@@ -32,33 +26,30 @@ protected:
     std::unique_ptr<rewrap::Lattice> hcp_ptr;
 };
 
-
-TEST_F(LatticeTest, ConstructandGetMatrix) { 
-	// This test constructs two different objects with the same matrix
-	// This test examines the functionality of the constructor and 
-	// column_vector_matrix()
-	EXPECT_EQ(fcc_ptr->column_vector_matrix(),
-		fcc2_ptr->column_vector_matrix());
+TEST_F(LatticeTest, ConstructandGetMatrix)
+{
+    // This test constructs two different objects with the same matrix
+    // This test examines the functionality of the constructor and
+    // column_vector_matrix()
+    EXPECT_EQ(fcc_ptr->column_vector_matrix(), fcc2_ptr->column_vector_matrix());
 }
 
-TEST_F(LatticeTest, BracketOperator) { 
-	//This test uses the bracket operator to check that the
-	//third vector of z oriented hcp is along the z direction
-	auto unitvec=(*hcp_ptr)[2]/(*hcp_ptr)[2].norm();
-	EXPECT_EQ(unitvec,
-		Eigen::Vector3d(0,0,1));
+TEST_F(LatticeTest, BracketOperator)
+{
+    // This test uses the bracket operator to check that the
+    // third vector of z oriented hcp is along the z direction
+    auto unitvec = (*hcp_ptr)[2] / (*hcp_ptr)[2].norm();
+    EXPECT_EQ(unitvec, Eigen::Vector3d(0, 0, 1));
 }
 
-TEST_F(LatticeTest, VectorAccess) { 
-	// This test grabs the vectors of a bcc lattice and sees that 
-	// the lengths are the same. Does the same for a and b of hcp
-	// tests a(), b(), c() 
-	EXPECT_EQ(bcc_ptr->a().norm(),
-			  bcc_ptr->b().norm());
-	EXPECT_EQ(bcc_ptr->a().norm(),
-			  bcc_ptr->c().norm());
-	EXPECT_EQ((hcp_ptr->a().norm()-
-			  hcp_ptr->b().norm())<1e-5,true);
+TEST_F(LatticeTest, VectorAccess)
+{
+    // This test grabs the vectors of a bcc lattice and sees that
+    // the lengths are the same. Does the same for a and b of hcp
+    // tests a(), b(), c()
+    EXPECT_EQ(bcc_ptr->a().norm(), bcc_ptr->b().norm());
+    EXPECT_EQ(bcc_ptr->a().norm(), bcc_ptr->c().norm());
+    EXPECT_EQ((hcp_ptr->a().norm() - hcp_ptr->b().norm()) < 1e-5, true);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Added three basic unit tests for rewrap::Lattice
Tests construction and convenient const access to lattice vectors.