### PR TITLE
0.4.x transition comparators

### DIFF
--- a/include/casmutils/xtal/lattice.hpp
+++ b/include/casmutils/xtal/lattice.hpp
@@ -41,21 +41,22 @@ namespace casmutils
 namespace xtal
 {
 using rewrap::Lattice;
-///This functor class provides a unary predicate equals function 
+/// This functor class provides a unary predicate equals function
 /// for casmutils::xtal::Lattice .
-class LatticeEquals_f {
-	public:
-		//The comparator requires a tolerance
-		LatticeEquals_f(const Lattice &ref_lat, double tol);
-		//returns true is ref_lat is equal to other
-		bool operator()(const Lattice &other);
-	private:
-		Lattice ref_lat;
-		double tol;
+class LatticeEquals_f
+{
+public:
+    // The comparator requires a tolerance
+    LatticeEquals_f(const Lattice& ref_lat, double tol);
+    // returns true is ref_lat is equal to other
+    bool operator()(const Lattice& other);
 
+private:
+    Lattice ref_lat;
+    double tol;
 };
 
-}
+} // namespace xtal
 } // namespace casmutils
 
 #endif

--- a/include/casmutils/xtal/lattice.hpp
+++ b/include/casmutils/xtal/lattice.hpp
@@ -41,6 +41,20 @@ namespace casmutils
 namespace xtal
 {
 using rewrap::Lattice;
+///This functor class provides a unary predicate equals function 
+/// for casmutils::xtal::Lattice .
+class LatticeEquals_f {
+	public:
+		//The comparator requires a tolerance
+		LatticeEquals_f(const Lattice &ref_lat, double tol);
+		//returns true is ref_lat is equal to other
+		bool operator()(const Lattice &other);
+	private:
+		Lattice ref_lat;
+		double tol;
+
+};
+
 }
 } // namespace casmutils
 

--- a/include/casmutils/xtal/site.hpp
+++ b/include/casmutils/xtal/site.hpp
@@ -47,19 +47,21 @@ namespace casmutils
 namespace xtal
 {
 using rewrap::Site;
-///This functor class provides a unary equals operator
+/// This functor class provides a unary equals operator
 /// for casmutils::xtal::Site
-class SiteEquals_f {
-	public:
-		///Equals compares to reference site with a tolerance
-		SiteEquals_f(const Site &ref_site, double tol);
-		///Returns true if other is equal to ref_site
-		bool operator()(const Site &other);
-	private:	
-		Site ref_site;
-		double tol;
+class SiteEquals_f
+{
+public:
+    /// Equals compares to reference site with a tolerance
+    SiteEquals_f(const Site& ref_site, double tol);
+    /// Returns true if other is equal to ref_site
+    bool operator()(const Site& other);
+
+private:
+    Site ref_site;
+    double tol;
 };
-}
+} // namespace xtal
 } // namespace casmutils
 
 #endif

--- a/include/casmutils/xtal/site.hpp
+++ b/include/casmutils/xtal/site.hpp
@@ -47,6 +47,18 @@ namespace casmutils
 namespace xtal
 {
 using rewrap::Site;
+///This functor class provides a unary equals operator
+/// for casmutils::xtal::Site
+class SiteEquals_f {
+	public:
+		///Equals compares to reference site with a tolerance
+		SiteEquals_f(const Site &ref_site, double tol);
+		///Returns true if other is equal to ref_site
+		bool operator()(const Site &other);
+	private:	
+		Site ref_site;
+		double tol;
+};
 }
 } // namespace casmutils
 

--- a/lib/casmutils/xtal/lattice.cxx
+++ b/lib/casmutils/xtal/lattice.cxx
@@ -8,11 +8,12 @@ Lattice::Lattice(const Eigen::Matrix3d& column_lat_mat) : casm_lattice(column_la
 
 namespace casmutils
 {
-	namespace xtal
-	{
-		LatticeEquals_f::LatticeEquals_f(const Lattice &ref_lat, double tol):ref_lat(ref_lat),tol(tol){}	
-		bool LatticeEquals_f::operator()(const Lattice &other){
-			return ref_lat.column_vector_matrix().isApprox(other.column_vector_matrix(),tol);
-		}
-	}	
+namespace xtal
+{
+LatticeEquals_f::LatticeEquals_f(const Lattice& ref_lat, double tol) : ref_lat(ref_lat), tol(tol) {}
+bool LatticeEquals_f::operator()(const Lattice& other)
+{
+    return ref_lat.column_vector_matrix().isApprox(other.column_vector_matrix(), tol);
 }
+} // namespace xtal
+} // namespace casmutils

--- a/lib/casmutils/xtal/lattice.cxx
+++ b/lib/casmutils/xtal/lattice.cxx
@@ -5,3 +5,14 @@ namespace rewrap
 Lattice::Lattice(const CASM::xtal::Lattice& init_lat) : casm_lattice(init_lat) {}
 Lattice::Lattice(const Eigen::Matrix3d& column_lat_mat) : casm_lattice(column_lat_mat) {}
 } // namespace rewrap
+
+namespace casmutils
+{
+	namespace xtal
+	{
+		LatticeEquals_f::LatticeEquals_f(const Lattice &ref_lat, double tol):ref_lat(ref_lat),tol(tol){}	
+		bool LatticeEquals_f::operator()(const Lattice &other){
+			return ref_lat.column_vector_matrix().isApprox(other.column_vector_matrix(),tol);
+		}
+	}	
+}

--- a/lib/casmutils/xtal/site.cxx
+++ b/lib/casmutils/xtal/site.cxx
@@ -34,3 +34,15 @@ Eigen::Vector3d Site::frac(const rewrap::Lattice& ref_lattice) const
 }
 
 } // namespace rewrap
+
+namespace casmutils
+{
+namespace xtal
+{
+	SiteEquals_f::SiteEquals_f(const Site &ref_site,double tol):ref_site(ref_site),tol(tol){}
+	bool SiteEquals_f::operator()(const Site &other){
+		return ref_site.cart().isApprox(other.cart(),tol) && ref_site.label()==other.label();
+	}
+
+}
+}

--- a/lib/casmutils/xtal/site.cxx
+++ b/lib/casmutils/xtal/site.cxx
@@ -39,10 +39,11 @@ namespace casmutils
 {
 namespace xtal
 {
-	SiteEquals_f::SiteEquals_f(const Site &ref_site,double tol):ref_site(ref_site),tol(tol){}
-	bool SiteEquals_f::operator()(const Site &other){
-		return ref_site.cart().isApprox(other.cart(),tol) && ref_site.label()==other.label();
-	}
+SiteEquals_f::SiteEquals_f(const Site& ref_site, double tol) : ref_site(ref_site), tol(tol) {}
+bool SiteEquals_f::operator()(const Site& other)
+{
+    return ref_site.cart().isApprox(other.cart(), tol) && ref_site.label() == other.label();
+}
 
-}
-}
+} // namespace xtal
+} // namespace casmutils

--- a/tests/unit/casmutils/lattice.cpp
+++ b/tests/unit/casmutils/lattice.cpp
@@ -51,12 +51,17 @@ TEST_F(LatticeTest, VectorAccess)
     EXPECT_EQ(bcc_ptr->a().norm(), bcc_ptr->c().norm());
     EXPECT_TRUE((hcp_ptr->a().norm() - hcp_ptr->b().norm()) < 1e-5);
 }
-TEST_F(LatticeTest,LatticeEquals){
-	// This test checks the ability to determine if two lattices
-	// are equivalent within numerical tolerance
-	double tol=1e-5;
-	casmutils::xtal::LatticeEquals_f equalizer(*fcc_ptr,tol);
-	EXPECT_TRUE(equalizer(*fcc2_ptr));
+TEST_F(LatticeTest, LatticeEquals)
+{
+	Eigen::Matrix3d fcc3_matrix;
+	fcc3_matrix << 0.0, 1.5, 1.5, 1.5, 0.0, 1.5, 1.5, 1.5+1e-4, 0.0;
+	casmutils::xtal::Lattice fcc3_lat(fcc3_matrix);
+    // This test checks the ability to determine if two lattices
+    // are equivalent within numerical tolerance
+    double tol = 1e-5;
+    casmutils::xtal::LatticeEquals_f equalizer(*fcc_ptr, tol);
+    EXPECT_TRUE(equalizer(*fcc2_ptr));
+	EXPECT_TRUE(!equalizer(fcc3_lat));
 }
 
 int main(int argc, char** argv)

--- a/tests/unit/casmutils/lattice.cpp
+++ b/tests/unit/casmutils/lattice.cpp
@@ -49,7 +49,14 @@ TEST_F(LatticeTest, VectorAccess)
     // tests a(), b(), c()
     EXPECT_EQ(bcc_ptr->a().norm(), bcc_ptr->b().norm());
     EXPECT_EQ(bcc_ptr->a().norm(), bcc_ptr->c().norm());
-    EXPECT_EQ((hcp_ptr->a().norm() - hcp_ptr->b().norm()) < 1e-5, true);
+    EXPECT_TRUE((hcp_ptr->a().norm() - hcp_ptr->b().norm()) < 1e-5);
+}
+TEST_F(LatticeTest,LatticeEquals){
+	// This test checks the ability to determine if two lattices
+	// are equivalent within numerical tolerance
+	double tol=1e-5;
+	casmutils::xtal::LatticeEquals_f equalizer(*fcc_ptr,tol);
+	EXPECT_TRUE(equalizer(*fcc2_ptr));
 }
 
 int main(int argc, char** argv)

--- a/tests/unit/casmutils/lattice.cpp
+++ b/tests/unit/casmutils/lattice.cpp
@@ -53,15 +53,15 @@ TEST_F(LatticeTest, VectorAccess)
 }
 TEST_F(LatticeTest, LatticeEquals)
 {
-	Eigen::Matrix3d fcc3_matrix;
-	fcc3_matrix << 0.0, 1.5, 1.5, 1.5, 0.0, 1.5, 1.5, 1.5+1e-4, 0.0;
-	casmutils::xtal::Lattice fcc3_lat(fcc3_matrix);
+    Eigen::Matrix3d fcc3_matrix;
+    fcc3_matrix << 0.0, 1.5, 1.5, 1.5, 0.0, 1.5, 1.5, 1.5 + 1e-4, 0.0;
+    casmutils::xtal::Lattice fcc3_lat(fcc3_matrix);
     // This test checks the ability to determine if two lattices
     // are equivalent within numerical tolerance
     double tol = 1e-5;
     casmutils::xtal::LatticeEquals_f equalizer(*fcc_ptr, tol);
     EXPECT_TRUE(equalizer(*fcc2_ptr));
-	EXPECT_TRUE(!equalizer(fcc3_lat));
+    EXPECT_TRUE(!equalizer(fcc3_lat));
 }
 
 int main(int argc, char** argv)

--- a/tests/unit/casmutils/site.cpp
+++ b/tests/unit/casmutils/site.cpp
@@ -53,9 +53,9 @@ TEST_F(SiteTest, FracConversion)
 };
 TEST_F(SiteTest, SiteEquals)
 {
-    // This test checks the ability to determine the equality of sites 
-	double tol=1e-5;
-	casmutils::xtal::SiteEquals_f equalizer(*lithium_site_ptr,tol);
+    // This test checks the ability to determine the equality of sites
+    double tol = 1e-5;
+    casmutils::xtal::SiteEquals_f equalizer(*lithium_site_ptr, tol);
     EXPECT_TRUE(equalizer(*lithium_site_ptr));
     EXPECT_TRUE(!equalizer(*nickel_site_ptr));
 };

--- a/tests/unit/casmutils/site.cpp
+++ b/tests/unit/casmutils/site.cpp
@@ -51,7 +51,14 @@ TEST_F(SiteTest, FracConversion)
     // coordinates of a site with respect to a lattice
     EXPECT_EQ(lithium_site_ptr->frac(*cubic_lattice_ptr), Eigen::Vector3d(0.025, 0.05, 0.075));
 };
-
+TEST_F(SiteTest, SiteEquals)
+{
+    // This test checks the ability to determine the equality of sites 
+	double tol=1e-5;
+	casmutils::xtal::SiteEquals_f equalizer(*lithium_site_ptr,tol);
+    EXPECT_TRUE(equalizer(*lithium_site_ptr));
+    EXPECT_TRUE(!equalizer(*nickel_site_ptr));
+};
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Added equals functors to casmutils::xtal::Lattice and casmutils::xtal::Site
Added basic tests to both (can be improved upon)