### PR TITLE
0.4.x transition structure tests

### DIFF
--- a/include/casmutils/exceptions.hpp
+++ b/include/casmutils/exceptions.hpp
@@ -33,7 +33,13 @@ public:
 
 private:
 };
+class BadPath : public std::runtime_error
+{
+public:
+    BadPath() : std::runtime_error("Invalid path specified, file does not exist.") {}
 
+private:
+};
 class OverwriteException : public std::runtime_error
 {
 public:

--- a/include/casmutils/exceptions.hpp
+++ b/include/casmutils/exceptions.hpp
@@ -1,6 +1,7 @@
 #ifndef CASM_UTILS_EXCPEPTIONS_HH
 #define CASM_UTILS_EXCPEPTIONS_HH
 
+#include <casmutils/definitions.hpp>
 #include <stdexcept>
 
 namespace except
@@ -36,7 +37,9 @@ private:
 class BadPath : public std::runtime_error
 {
 public:
-    BadPath() : std::runtime_error("Invalid path specified, file does not exist.") {}
+    BadPath(const casmutils::fs::path& path) : std::runtime_error("Invalid path specified, Received: " + path.string())
+    {
+    }
 
 private:
 };

--- a/include/casmutils/misc.hpp
+++ b/include/casmutils/misc.hpp
@@ -16,6 +16,17 @@ class Structure;
 class PrimClex;
 } // namespace CASM
 
+namespace casmutils
+{
+
+template <typename ComparatorType_f, typename CompareType, typename... Args>
+bool is_equal(const CompareType& reference, const CompareType& other, const Args&... functor_params)
+{
+    ComparatorType_f reference_equals(reference, functor_params...);
+    return reference_equals(other);
+}
+} // namespace casmutils
+
 /**
  * This namespace is reserved for convenience functions
  * that reduce boilerplate code within library functions
@@ -24,7 +35,6 @@ class PrimClex;
  * outside of any implementation, these are not utility
  * library functions, they're just here for convenience.
  */
-
 namespace extend
 {
 /// Make a PrimClex but shut up about it

--- a/include/casmutils/xtal/lattice.hpp
+++ b/include/casmutils/xtal/lattice.hpp
@@ -41,21 +41,22 @@ namespace casmutils
 namespace xtal
 {
 using rewrap::Lattice;
-///This functor class provides a unary predicate equals function 
+/// This functor class provides a unary predicate equals function
 /// for casmutils::xtal::Lattice .
-class LatticeEquals_f {
-	public:
-		//The comparator requires a tolerance
-		LatticeEquals_f(const Lattice &ref_lat, double tol);
-		//returns true is ref_lat is equal to other
-		bool operator()(const Lattice &other);
-	private:
-		Lattice ref_lat;
-		double tol;
+class LatticeEquals_f
+{
+public:
+    // The comparator requires a tolerance
+    LatticeEquals_f(const Lattice& ref_lat, double tol);
+    // returns true is ref_lat is equal to other
+    bool operator()(const Lattice& other);
 
+private:
+    Lattice ref_lat;
+    double tol;
 };
 
-}
+} // namespace xtal
 } // namespace casmutils
 
 #endif

--- a/include/casmutils/xtal/lattice.hpp
+++ b/include/casmutils/xtal/lattice.hpp
@@ -25,9 +25,12 @@ public:
 
     /// Return the third vector of the lattice
     Eigen::Vector3d c() const { return this->operator[](2); }
-
+    /// Return the volume of this lattice
     double volume() const { return this->__get().volume(); }
+
+    /// Returns the matrix representation of this lattice where each lattice vector is a column
     Eigen::Matrix3d column_vector_matrix() const { return this->__get().lat_column_mat(); }
+
     /// Return *this as a CASM::Lattice
     const CASM::xtal::Lattice& __get() const { return this->casm_lattice; }
 
@@ -46,9 +49,9 @@ using rewrap::Lattice;
 class LatticeEquals_f
 {
 public:
-    // The comparator requires a tolerance
+    /// The comparator requires a tolerance
     LatticeEquals_f(const Lattice& ref_lat, double tol);
-    // returns true is ref_lat is equal to other
+    /// returns true is ref_lat is equal to other
     bool operator()(const Lattice& other);
 
 private:

--- a/include/casmutils/xtal/lattice.hpp
+++ b/include/casmutils/xtal/lattice.hpp
@@ -41,6 +41,20 @@ namespace casmutils
 namespace xtal
 {
 using rewrap::Lattice;
+///This functor class provides a unary predicate equals function 
+/// for casmutils::xtal::Lattice .
+class LatticeEquals_f {
+	public:
+		//The comparator requires a tolerance
+		LatticeEquals_f(const Lattice &ref_lat, double tol);
+		//returns true is ref_lat is equal to other
+		bool operator()(const Lattice &other);
+	private:
+		Lattice ref_lat;
+		double tol;
+
+};
+
 }
 } // namespace casmutils
 

--- a/include/casmutils/xtal/site.hpp
+++ b/include/casmutils/xtal/site.hpp
@@ -52,7 +52,7 @@ using rewrap::Site;
 class SiteEquals_f
 {
 public:
-    /// Equals compares to reference site with a tolerance
+    /// Determines whether test is equal to reference site with a tolerance
     SiteEquals_f(const Site& ref_site, double tol);
     /// Returns true if other is equal to ref_site
     bool operator()(const Site& other);

--- a/include/casmutils/xtal/site.hpp
+++ b/include/casmutils/xtal/site.hpp
@@ -19,7 +19,7 @@ class Site
 {
 public:
     Site() = delete;
-    Site(const CASM::xtal::Site& init_site, int occupant) : casm_site(init_site) {}
+    Site(const CASM::xtal::Site& init_site, int occupant);
     Site(const Coordinate& init_coord, const std::string& occupant_name);
     /* Site(const Eigen::Vector3d& init_coord, const std::string& occupant_name); */
 

--- a/include/casmutils/xtal/site.hpp
+++ b/include/casmutils/xtal/site.hpp
@@ -47,19 +47,21 @@ namespace casmutils
 namespace xtal
 {
 using rewrap::Site;
-///This functor class provides a unary equals operator
+/// This functor class provides a unary equals operator
 /// for casmutils::xtal::Site
-class SiteEquals_f {
-	public:
-		///Equals compares to reference site with a tolerance
-		SiteEquals_f(const Site &ref_site, double tol);
-		///Returns true if other is equal to ref_site
-		bool operator()(const Site &other);
-	private:	
-		Site ref_site;
-		double tol;
+class SiteEquals_f
+{
+public:
+    /// Equals compares to reference site with a tolerance
+    SiteEquals_f(const Site& ref_site, double tol);
+    /// Returns true if other is equal to ref_site
+    bool operator()(const Site& other);
+
+private:
+    Site ref_site;
+    double tol;
 };
-}
+} // namespace xtal
 } // namespace casmutils
 
 #endif

--- a/include/casmutils/xtal/site.hpp
+++ b/include/casmutils/xtal/site.hpp
@@ -47,6 +47,18 @@ namespace casmutils
 namespace xtal
 {
 using rewrap::Site;
+///This functor class provides a unary equals operator
+/// for casmutils::xtal::Site
+class SiteEquals_f {
+	public:
+		///Equals compares to reference site with a tolerance
+		SiteEquals_f(const Site &ref_site, double tol);
+		///Returns true if other is equal to ref_site
+		bool operator()(const Site &other);
+	private:	
+		Site ref_site;
+		double tol;
+};
 }
 } // namespace casmutils
 

--- a/include/casmutils/xtal/structure.hpp
+++ b/include/casmutils/xtal/structure.hpp
@@ -48,6 +48,32 @@ public:
     template <typename CASMType> const CASMType& __get() const;
 
 private:
+    /// This function updates the appropriate members using
+    /// the flag given as a reference
+    void _update_using(std::string reference);
+    /// This function updates the casm_simplestructure member
+    /// using casm_basicstructure as a reference
+    void _update_simple_from_basic();
+    /// This function updates the casm_basicstructure member
+    /// using casm_simplestructure as a reference
+    void _update_basic_from_simple();
+
+    /// This function updates the lattice and basis member
+    /// using casm_simplestructure as a reference
+    void _update_internals_from_simple();
+
+    /// This function updates the lattice and basis member
+    /// using casm_basicstructure as a reference
+    void _update_internals_from_basic();
+
+    /// This function updates casm_basicstructure
+    /// using the lattice and basis member as a reference
+    void _update_basic_from_internals();
+
+    /// This function updates casm_simplestructure
+    /// using the lattice and basis member as a reference
+    void _update_simple_from_internals();
+
     /// CASM::SimpleStructure representation
     CASM::xtal::SimpleStructure casm_simplestructure;
 

--- a/include/casmutils/xtal/structure.hpp
+++ b/include/casmutils/xtal/structure.hpp
@@ -66,11 +66,11 @@ namespace casmutils
 {
 namespace xtal
 {
-using rewrap::Structure;
+using rewrap::CART;
 using rewrap::COORD_TYPE;
 using rewrap::FRAC;
-using rewrap::CART;
-}
+using rewrap::Structure;
+} // namespace xtal
 } // namespace casmutils
 
 #endif

--- a/include/casmutils/xtal/structure.hpp
+++ b/include/casmutils/xtal/structure.hpp
@@ -39,7 +39,7 @@ public:
     void set_lattice(const Lattice& new_lattice, COORD_TYPE mode);
 
     /// Give the structure a new lattice, and either keep the Cartesian, or fractional coordinates of the basis
-    Structure set_lattice(const Lattice& new_lattice, COORD_TYPE mode) const;
+    [[nodiscard]] Structure set_lattice(const Lattice& new_lattice, COORD_TYPE mode) const;
 
     /// Return a copy of all the basis sites
     const std::vector<Site>& basis_sites() const;
@@ -67,6 +67,9 @@ namespace casmutils
 namespace xtal
 {
 using rewrap::Structure;
+using rewrap::COORD_TYPE;
+using rewrap::FRAC;
+using rewrap::CART;
 }
 } // namespace casmutils
 

--- a/include/casmutils/xtal/structure.hpp
+++ b/include/casmutils/xtal/structure.hpp
@@ -49,8 +49,8 @@ public:
 
 private:
     ///  updates the appropriate members using
-    /// the argument given as a reference
-    template <typename StructureRepresentation> void _update_using(const StructureRepresentation& struc);
+    /// the template type given as a reference
+    template <typename StructureRepresentation> void _update_using();
     ///  updates the casm_simplestructure member
     /// using casm_basicstructure as a reference
     void _update_simple_from_basic();

--- a/include/casmutils/xtal/structure.hpp
+++ b/include/casmutils/xtal/structure.hpp
@@ -48,29 +48,29 @@ public:
     template <typename CASMType> const CASMType& __get() const;
 
 private:
-    /// This function updates the appropriate members using
-    /// the flag given as a reference
-    void _update_using(std::string reference);
-    /// This function updates the casm_simplestructure member
+    ///  updates the appropriate members using
+    /// the argument given as a reference
+    template <typename StructureRepresentation> void _update_using(const StructureRepresentation& struc);
+    ///  updates the casm_simplestructure member
     /// using casm_basicstructure as a reference
     void _update_simple_from_basic();
-    /// This function updates the casm_basicstructure member
+    ///  updates the casm_basicstructure member
     /// using casm_simplestructure as a reference
     void _update_basic_from_simple();
 
-    /// This function updates the lattice and basis member
+    ///  updates the lattice and basis member
     /// using casm_simplestructure as a reference
     void _update_internals_from_simple();
 
-    /// This function updates the lattice and basis member
+    ///  updates the lattice and basis member
     /// using casm_basicstructure as a reference
     void _update_internals_from_basic();
 
-    /// This function updates casm_basicstructure
+    ///  updates casm_basicstructure
     /// using the lattice and basis member as a reference
     void _update_basic_from_internals();
 
-    /// This function updates casm_simplestructure
+    ///  updates casm_simplestructure
     /// using the lattice and basis member as a reference
     void _update_simple_from_internals();
 

--- a/lib/casmutils/xtal/lattice.cxx
+++ b/lib/casmutils/xtal/lattice.cxx
@@ -8,11 +8,12 @@ Lattice::Lattice(const Eigen::Matrix3d& column_lat_mat) : casm_lattice(column_la
 
 namespace casmutils
 {
-	namespace xtal
-	{
-		LatticeEquals_f::LatticeEquals_f(const Lattice &ref_lat, double tol):ref_lat(ref_lat),tol(tol){}	
-		bool LatticeEquals_f::operator()(const Lattice &other){
-			return ref_lat.column_vector_matrix().isApprox(other.column_vector_matrix(),tol);
-		}
-	}	
+namespace xtal
+{
+LatticeEquals_f::LatticeEquals_f(const Lattice& ref_lat, double tol) : ref_lat(ref_lat), tol(tol) {}
+bool LatticeEquals_f::operator()(const Lattice& other)
+{
+    return ref_lat.column_vector_matrix().isApprox(other.column_vector_matrix(), tol);
 }
+} // namespace xtal
+} // namespace casmutils

--- a/lib/casmutils/xtal/lattice.cxx
+++ b/lib/casmutils/xtal/lattice.cxx
@@ -5,3 +5,14 @@ namespace rewrap
 Lattice::Lattice(const CASM::xtal::Lattice& init_lat) : casm_lattice(init_lat) {}
 Lattice::Lattice(const Eigen::Matrix3d& column_lat_mat) : casm_lattice(column_lat_mat) {}
 } // namespace rewrap
+
+namespace casmutils
+{
+	namespace xtal
+	{
+		LatticeEquals_f::LatticeEquals_f(const Lattice &ref_lat, double tol):ref_lat(ref_lat),tol(tol){}	
+		bool LatticeEquals_f::operator()(const Lattice &other){
+			return ref_lat.column_vector_matrix().isApprox(other.column_vector_matrix(),tol);
+		}
+	}	
+}

--- a/lib/casmutils/xtal/site.cxx
+++ b/lib/casmutils/xtal/site.cxx
@@ -23,7 +23,11 @@ Site::Site(const rewrap::Coordinate& init_coord, const std::string& occupant_nam
     // Avoid an unitialized state.
     this->casm_site.set_label(0);
 }
-
+Site::Site(const CASM::xtal::Site& init_site, int occupant) : casm_site(init_site)
+{
+    // Avoid an unitialized state.
+    this->casm_site.set_label(occupant);
+}
 std::string Site::label() const { return this->casm_site.allowed_occupants()[this->casm_site.label()]; }
 
 Eigen::Vector3d Site::cart() const { return this->casm_site.cart(); }

--- a/lib/casmutils/xtal/site.cxx
+++ b/lib/casmutils/xtal/site.cxx
@@ -34,3 +34,15 @@ Eigen::Vector3d Site::frac(const rewrap::Lattice& ref_lattice) const
 }
 
 } // namespace rewrap
+
+namespace casmutils
+{
+namespace xtal
+{
+	SiteEquals_f::SiteEquals_f(const Site &ref_site,double tol):ref_site(ref_site),tol(tol){}
+	bool SiteEquals_f::operator()(const Site &other){
+		return ref_site.cart().isApprox(other.cart(),tol) && ref_site.label()==other.label();
+	}
+
+}
+}

--- a/lib/casmutils/xtal/site.cxx
+++ b/lib/casmutils/xtal/site.cxx
@@ -39,10 +39,11 @@ namespace casmutils
 {
 namespace xtal
 {
-	SiteEquals_f::SiteEquals_f(const Site &ref_site,double tol):ref_site(ref_site),tol(tol){}
-	bool SiteEquals_f::operator()(const Site &other){
-		return ref_site.cart().isApprox(other.cart(),tol) && ref_site.label()==other.label();
-	}
+SiteEquals_f::SiteEquals_f(const Site& ref_site, double tol) : ref_site(ref_site), tol(tol) {}
+bool SiteEquals_f::operator()(const Site& other)
+{
+    return ref_site.cart().isApprox(other.cart(), tol) && ref_site.label() == other.label();
+}
 
-}
-}
+} // namespace xtal
+} // namespace casmutils

--- a/lib/casmutils/xtal/structure.cxx
+++ b/lib/casmutils/xtal/structure.cxx
@@ -1,28 +1,31 @@
+#include <casm/crystallography/SimpleStructure.hh>
+#include <casm/crystallography/SimpleStructureTools.hh>
+#include <casm/crystallography/Structure.hh>
 #include <casmutils/definitions.hpp>
 #include <casmutils/exceptions.hpp>
 #include <casmutils/misc.hpp>
+#include <casmutils/xtal/coordinate.hpp>
 #include <casmutils/xtal/structure.hpp>
-
 namespace extend
 {
 } // namespace extend
 
 namespace rewrap
 {
-Structure::Structure(const CASM::xtal::BasicStructure& init_struc) : structure_lattice(init_struc.lattice())
+Structure::Structure(const CASM::xtal::BasicStructure& init_struc)
+    : structure_lattice(init_struc.lattice()), casm_basicstructure(init_struc)
 {
-    throw except::NotImplemented();
+    _update_using("basic");
 }
-
-Structure::Structure(const rewrap::Lattice& init_lat, const std::vector<rewrap::Site>& init_basis)
-    : structure_lattice(init_lat)
+Structure::Structure(const CASM::xtal::SimpleStructure& init_struc)
+    : structure_lattice(init_struc.lat_column_mat), casm_simplestructure(init_struc)
 {
-    throw except::NotImplemented();
-    /* for (const auto& site : init_basis) */
-    /* { */
-    /*     this->basis.push_back(site.__get()); */
-    /*     basis.back().set_lattice(this->lattice(), CASM::CART); */
-    /* } */
+    _update_using("simple");
+}
+Structure::Structure(const rewrap::Lattice& init_lat, const std::vector<rewrap::Site>& init_basis)
+    : structure_lattice(init_lat), basis(init_basis)
+{
+    _update_using("internal");
 }
 
 Structure Structure::from_poscar(const fs::path& poscar_path) { throw except::NotImplemented(); }
@@ -39,12 +42,100 @@ void Structure::set_lattice(const Lattice& new_lattice, COORD_TYPE mode)
 {
     throw except::NotImplemented();
 }
-const std::vector<Site>& Structure::basis_sites() const
+const std::vector<Site>& Structure::basis_sites() const { return this->basis; }
+
+void Structure::_update_using(std::string reference)
 {
-    throw except::NotImplemented();
-    // You are dealing with CASM::Array, but we want to return a std::vector
-    // std::vector<Site> basis(this->basis.begin(), this->basis.end());
-    // return basis;
+    if (reference == "basic")
+    {
+        _update_simple_from_basic();
+        _update_internals_from_basic();
+    }
+    else if (reference == "simple")
+    {
+        _update_basic_from_simple();
+        _update_internals_from_simple();
+    }
+    else if (reference == "internal")
+    {
+        _update_basic_from_internals();
+        _update_simple_from_internals();
+    }
+    else
+    {
+        throw except::UserInputMangle("Check the update reference you used. Not compatible.");
+    }
+}
+
+void Structure::_update_simple_from_basic()
+{
+    this->casm_simplestructure = CASM::xtal::make_simple_structure(this->casm_basicstructure);
+}
+
+void Structure::_update_internals_from_basic()
+{
+    this->structure_lattice = casmutils::xtal::Lattice(this->casm_basicstructure.lattice());
+    this->basis.clear();
+    for (const auto& site : this->casm_basicstructure.basis())
+    {
+        this->basis.emplace_back(site, 0);
+    }
+}
+
+void Structure::_update_basic_from_simple()
+{
+    /// Syncing Lattice
+    this->casm_basicstructure =
+        CASM::xtal::BasicStructure(CASM::xtal::Lattice(this->casm_simplestructure.lat_column_mat));
+    /// Lattice has been synced
+    auto& basic_basis = this->casm_basicstructure.set_basis();
+    for (int index = 0; index < this->casm_simplestructure.n_atom(); index++)
+    {
+        const auto& info = this->casm_simplestructure.info(CASM::xtal::SimpleStructure::SpeciesMode::ATOM);
+        Eigen::Vector3d raw_coord = info.coord(index);
+        basic_basis.emplace_back(CASM::xtal::Coordinate(raw_coord, this->casm_basicstructure.lattice(), CASM::CART),
+                                 info.names[index]);
+    }
+}
+
+void Structure::_update_internals_from_simple()
+{
+    this->structure_lattice = casmutils::xtal::Lattice(casm_simplestructure.lat_column_mat);
+    this->basis.clear();
+    for (int index = 0; index < this->casm_simplestructure.n_atom(); index++)
+    {
+        const auto& info = this->casm_simplestructure.info(CASM::xtal::SimpleStructure::SpeciesMode::ATOM);
+        Eigen::Vector3d raw_coord = info.coord(index);
+        this->basis.emplace_back(casmutils::xtal::Coordinate(raw_coord), info.names[index]);
+    }
+}
+
+void Structure::_update_basic_from_internals()
+{
+    /// Syncing Lattice
+    this->casm_basicstructure =
+        CASM::xtal::BasicStructure(CASM::xtal::Lattice(this->structure_lattice.column_vector_matrix()));
+    /// Lattice has been synced
+    auto& basic_basis = this->casm_basicstructure.set_basis();
+    for (const auto& site : this->basis)
+    {
+        basic_basis.emplace_back(CASM::xtal::Coordinate(site.cart(), this->casm_basicstructure.lattice(), CASM::CART),
+                                 site.label());
+    }
+}
+
+void Structure::_update_simple_from_internals()
+{
+    /// This seems like a horrible way to do this but it's because SimpleStructure only has a
+    // default constructor and a whole bunch of empty fields.
+    // I also didn't want to call _update_basic_from_internals here.
+    CASM::xtal::BasicStructure temp_basic(CASM::xtal::Lattice(this->structure_lattice.column_vector_matrix()));
+    auto& basic_basis = temp_basic.set_basis();
+    for (const auto& site : this->basis)
+    {
+        basic_basis.emplace_back(CASM::xtal::Coordinate(site.cart(), temp_basic.lattice(), CASM::CART), site.label());
+    }
+    this->casm_simplestructure = CASM::xtal::make_simple_structure(temp_basic);
 }
 
 /// Return *this as a CASM::BasicStructure

--- a/lib/casmutils/xtal/structure.cxx
+++ b/lib/casmutils/xtal/structure.cxx
@@ -35,6 +35,9 @@ void Structure::set_lattice(const Lattice& new_lattice, COORD_TYPE mode)
     return;
 }
 
+[[nodiscard]] Structure Structure::set_lattice(const Lattice& new_lattice, COORD_TYPE mode) const{
+	throw except::NotImplemented();
+}
 const std::vector<Site>& Structure::basis_sites() const
 {
     throw except::NotImplemented();
@@ -42,6 +45,8 @@ const std::vector<Site>& Structure::basis_sites() const
     // std::vector<Site> basis(this->basis.begin(), this->basis.end());
     // return basis;
 }
+
+
 
 /// Return *this as a CASM::BasicStructure
 template <> const CASM::xtal::SimpleStructure& Structure::__get<CASM::xtal::SimpleStructure>() const

--- a/lib/casmutils/xtal/structure.cxx
+++ b/lib/casmutils/xtal/structure.cxx
@@ -35,8 +35,9 @@ void Structure::set_lattice(const Lattice& new_lattice, COORD_TYPE mode)
     return;
 }
 
-[[nodiscard]] Structure Structure::set_lattice(const Lattice& new_lattice, COORD_TYPE mode) const{
-	throw except::NotImplemented();
+[[nodiscard]] Structure Structure::set_lattice(const Lattice& new_lattice, COORD_TYPE mode) const
+{
+    throw except::NotImplemented();
 }
 const std::vector<Site>& Structure::basis_sites() const
 {
@@ -45,8 +46,6 @@ const std::vector<Site>& Structure::basis_sites() const
     // std::vector<Site> basis(this->basis.begin(), this->basis.end());
     // return basis;
 }
-
-
 
 /// Return *this as a CASM::BasicStructure
 template <> const CASM::xtal::SimpleStructure& Structure::__get<CASM::xtal::SimpleStructure>() const

--- a/lib/casmutils/xtal/structure.cxx
+++ b/lib/casmutils/xtal/structure.cxx
@@ -1,12 +1,12 @@
+#include <casm/crystallography/BasicStructure.hh>
 #include <casm/crystallography/SimpleStructure.hh>
 #include <casm/crystallography/SimpleStructureTools.hh>
-#include <casm/crystallography/BasicStructure.hh>
+#include <casm/global/definitions.hh>
 #include <casmutils/definitions.hpp>
 #include <casmutils/exceptions.hpp>
 #include <casmutils/misc.hpp>
 #include <casmutils/xtal/coordinate.hpp>
 #include <casmutils/xtal/structure.hpp>
-#include <casm/global/definitions.hh>
 #include <fstream>
 namespace extend
 {
@@ -30,30 +30,32 @@ Structure::Structure(const rewrap::Lattice& init_lat, const std::vector<rewrap::
     _update_using("internal");
 }
 
-Structure Structure::from_poscar(const fs::path& poscar_path) {
-	CASM::xtal::BasicStructure pos;
-      if(!fs::exists(poscar_path)) {
-		  throw except::UserInputMangle("Path does not exist");
-      }
-      std::ifstream infile(poscar_path);
-      pos.read(infile);
-	return casmutils::xtal::Structure(pos);
+Structure Structure::from_poscar(const fs::path& poscar_path)
+{
+    CASM::xtal::BasicStructure pos;
+    if (!fs::exists(poscar_path))
+    {
+        throw except::UserInputMangle("Path does not exist");
+    }
+    std::ifstream infile(poscar_path);
+    pos.read(infile);
+    return casmutils::xtal::Structure(pos);
 }
 
 const Lattice& Structure::lattice() const { return this->structure_lattice; }
 
 void Structure::set_lattice(const Lattice& new_lattice, COORD_TYPE mode)
 {
-	this->casm_basicstructure.set_lattice(CASM::xtal::Lattice(new_lattice.column_vector_matrix()),mode);
-	_update_using("basic");
+    this->casm_basicstructure.set_lattice(CASM::xtal::Lattice(new_lattice.column_vector_matrix()), mode);
+    _update_using("basic");
     return;
 }
 
 [[nodiscard]] Structure Structure::set_lattice(const Lattice& new_lattice, COORD_TYPE mode) const
 {
-	casmutils::xtal::Structure new_struc=*this;
-	new_struc.set_lattice(new_lattice,mode);
-	return new_struc;
+    casmutils::xtal::Structure new_struc = *this;
+    new_struc.set_lattice(new_lattice, mode);
+    return new_struc;
 }
 const std::vector<Site>& Structure::basis_sites() const { return this->basis; }
 

--- a/lib/casmutils/xtal/structure.cxx
+++ b/lib/casmutils/xtal/structure.cxx
@@ -90,11 +90,12 @@ void Structure::_update_simple_from_basic()
 void Structure::_update_internals_from_basic()
 {
     this->structure_lattice = casmutils::xtal::Lattice(this->casm_basicstructure.lattice());
-    this->basis.clear();
+    std::vector<casmutils::xtal::Site> new_basis;
     for (const auto& site : this->casm_basicstructure.basis())
     {
-        this->basis.emplace_back(site, 0);
+        new_basis.emplace_back(site, 0);
     }
+    this->basis = new_basis;
 }
 
 void Structure::_update_basic_from_simple()
@@ -116,13 +117,14 @@ void Structure::_update_basic_from_simple()
 void Structure::_update_internals_from_simple()
 {
     this->structure_lattice = casmutils::xtal::Lattice(casm_simplestructure.lat_column_mat);
-    this->basis.clear();
+    std::vector<casmutils::xtal::Site> new_basis;
     for (int index = 0; index < this->casm_simplestructure.n_atom(); index++)
     {
         const auto& info = this->casm_simplestructure.info(CASM::xtal::SimpleStructure::SpeciesMode::ATOM);
         Eigen::Vector3d raw_coord = info.coord(index);
-        this->basis.emplace_back(casmutils::xtal::Coordinate(raw_coord), info.names[index]);
+        new_basis.emplace_back(casmutils::xtal::Coordinate(raw_coord), info.names[index]);
     }
+    this->basis = new_basis;
 }
 
 void Structure::_update_basic_from_internals()

--- a/lib/casmutils/xtal/structure.cxx
+++ b/lib/casmutils/xtal/structure.cxx
@@ -66,7 +66,7 @@ Structure Structure::from_poscar(const fs::path& poscar_path)
     CASM::xtal::BasicStructure pos;
     if (!fs::exists(poscar_path))
     {
-        throw except::BadPath();
+        throw except::BadPath(poscar_path);
     }
     std::ifstream infile(poscar_path);
     pos.read(infile);

--- a/lib/casmutils/xtal/structure.cxx
+++ b/lib/casmutils/xtal/structure.cxx
@@ -1,11 +1,13 @@
 #include <casm/crystallography/SimpleStructure.hh>
 #include <casm/crystallography/SimpleStructureTools.hh>
-#include <casm/crystallography/Structure.hh>
+#include <casm/crystallography/BasicStructure.hh>
 #include <casmutils/definitions.hpp>
 #include <casmutils/exceptions.hpp>
 #include <casmutils/misc.hpp>
 #include <casmutils/xtal/coordinate.hpp>
 #include <casmutils/xtal/structure.hpp>
+#include <casm/global/definitions.hh>
+#include <fstream>
 namespace extend
 {
 } // namespace extend
@@ -28,19 +30,30 @@ Structure::Structure(const rewrap::Lattice& init_lat, const std::vector<rewrap::
     _update_using("internal");
 }
 
-Structure Structure::from_poscar(const fs::path& poscar_path) { throw except::NotImplemented(); }
+Structure Structure::from_poscar(const fs::path& poscar_path) {
+	CASM::xtal::BasicStructure pos;
+      if(!fs::exists(poscar_path)) {
+		  throw except::UserInputMangle("Path does not exist");
+      }
+      std::ifstream infile(poscar_path);
+      pos.read(infile);
+	return casmutils::xtal::Structure(pos);
+}
 
 const Lattice& Structure::lattice() const { return this->structure_lattice; }
 
 void Structure::set_lattice(const Lattice& new_lattice, COORD_TYPE mode)
 {
-    throw except::NotImplemented();
+	this->casm_basicstructure.set_lattice(CASM::xtal::Lattice(new_lattice.column_vector_matrix()),mode);
+	_update_using("basic");
     return;
 }
 
 [[nodiscard]] Structure Structure::set_lattice(const Lattice& new_lattice, COORD_TYPE mode) const
 {
-    throw except::NotImplemented();
+	casmutils::xtal::Structure new_struc=*this;
+	new_struc.set_lattice(new_lattice,mode);
+	return new_struc;
 }
 const std::vector<Site>& Structure::basis_sites() const { return this->basis; }
 

--- a/lib/casmutils/xtal/structure.cxx
+++ b/lib/casmutils/xtal/structure.cxx
@@ -15,19 +15,19 @@ namespace extend
 namespace rewrap
 {
 
-template <> void Structure::_update_using<CASM::xtal::BasicStructure>(const CASM::xtal::BasicStructure& struc)
+template <> void Structure::_update_using<CASM::xtal::BasicStructure>()
 {
     _update_simple_from_basic();
     _update_internals_from_basic();
 }
 
-template <> void Structure::_update_using<CASM::xtal::SimpleStructure>(const CASM::xtal::SimpleStructure& struc)
+template <> void Structure::_update_using<CASM::xtal::SimpleStructure>()
 {
     _update_basic_from_simple();
     _update_internals_from_simple();
 }
 
-template <> void Structure::_update_using<casmutils::xtal::Structure>(const casmutils::xtal::Structure& struc)
+template <> void Structure::_update_using<casmutils::xtal::Structure>()
 {
     _update_basic_from_internals();
     _update_simple_from_internals();
@@ -48,17 +48,17 @@ template <> const CASM::xtal::BasicStructure& Structure::__get<CASM::xtal::Basic
 Structure::Structure(const CASM::xtal::BasicStructure& init_struc)
     : structure_lattice(init_struc.lattice()), casm_basicstructure(init_struc)
 {
-    _update_using(this->__get<CASM::xtal::BasicStructure>());
+    _update_using<CASM::xtal::BasicStructure>();
 }
 Structure::Structure(const CASM::xtal::SimpleStructure& init_struc)
     : structure_lattice(init_struc.lat_column_mat), casm_simplestructure(init_struc)
 {
-    _update_using(this->__get<CASM::xtal::SimpleStructure>());
+    _update_using<CASM::xtal::SimpleStructure>();
 }
 Structure::Structure(const rewrap::Lattice& init_lat, const std::vector<rewrap::Site>& init_basis)
     : structure_lattice(init_lat), basis(init_basis)
 {
-    _update_using(*this);
+    _update_using<casmutils::xtal::Structure>();
 }
 
 Structure Structure::from_poscar(const fs::path& poscar_path)
@@ -78,7 +78,7 @@ const Lattice& Structure::lattice() const { return this->structure_lattice; }
 void Structure::set_lattice(const Lattice& new_lattice, COORD_TYPE mode)
 {
     this->casm_basicstructure.set_lattice(CASM::xtal::Lattice(new_lattice.column_vector_matrix()), mode);
-    _update_using(this->__get<CASM::xtal::BasicStructure>());
+    _update_using<CASM::xtal::BasicStructure>();
     return;
 }
 
@@ -108,10 +108,10 @@ void Structure::_update_internals_from_basic()
 
 void Structure::_update_basic_from_simple()
 {
-    /// Syncing Lattice
+    // Syncing Lattice
     this->casm_basicstructure =
         CASM::xtal::BasicStructure(CASM::xtal::Lattice(this->__get<CASM::xtal::SimpleStructure>().lat_column_mat));
-    /// Lattice has been synced
+    // Lattice has been synced
     auto& basic_basis = this->casm_basicstructure.set_basis();
     for (int index = 0; index < this->__get<CASM::xtal::SimpleStructure>().n_atom(); index++)
     {
@@ -140,10 +140,10 @@ void Structure::_update_internals_from_simple()
 
 void Structure::_update_basic_from_internals()
 {
-    /// Syncing Lattice
+    // Syncing Lattice
     this->casm_basicstructure =
         CASM::xtal::BasicStructure(CASM::xtal::Lattice(this->structure_lattice.column_vector_matrix()));
-    /// Lattice has been synced
+    // Lattice has been synced
     auto& basic_basis = this->casm_basicstructure.set_basis();
     for (const auto& site : this->basis)
     {
@@ -155,7 +155,7 @@ void Structure::_update_basic_from_internals()
 
 void Structure::_update_simple_from_internals()
 {
-    /// This seems like a horrible way to do this but it's because SimpleStructure only has a
+    // This seems like a horrible way to do this but it's because SimpleStructure only has a
     // default constructor and a whole bunch of empty fields.
     // I also didn't want to call _update_basic_from_internals here.
     CASM::xtal::BasicStructure temp_basic(CASM::xtal::Lattice(this->structure_lattice.column_vector_matrix()));

--- a/tests/input_files/simple_cubic_Ni.vasp
+++ b/tests/input_files/simple_cubic_Ni.vasp
@@ -1,0 +1,11 @@
+Ni_cubic
+1.0
+2 0 0
+0 2 0
+0 0 2
+Ni
+1
+Cartesian
+0 0 1 Ni
+
+

--- a/tests/unit/casmutils/lattice.cpp
+++ b/tests/unit/casmutils/lattice.cpp
@@ -10,7 +10,7 @@ protected:
         Eigen::Matrix3d fcc_matrix;
         fcc_matrix << 0.0, 1.5, 1.5, 1.5, 0.0, 1.5, 1.5, 1.5, 0.0;
         fcc_ptr.reset(new rewrap::Lattice(fcc_matrix));
-        fcc2_ptr.reset(new rewrap::Lattice(fcc_matrix));
+        fcc_copy_ptr.reset(new rewrap::Lattice(fcc_matrix));
         Eigen::Matrix3d bcc_matrix;
         bcc_matrix << -1.5, 1.5, 1.5, 1.5, -1.5, 1.5, 1.5, 1.5, -1.5;
         bcc_ptr.reset(new rewrap::Lattice(bcc_matrix));
@@ -21,8 +21,10 @@ protected:
 
     // Use unique pointers because Lattice has no default constructor
     std::unique_ptr<rewrap::Lattice> fcc_ptr;
-    std::unique_ptr<rewrap::Lattice> fcc2_ptr;
+    std::unique_ptr<rewrap::Lattice> fcc_copy_ptr;
+
     std::unique_ptr<rewrap::Lattice> bcc_ptr;
+
     std::unique_ptr<rewrap::Lattice> hcp_ptr;
 };
 
@@ -31,7 +33,7 @@ TEST_F(LatticeTest, ConstructandGetMatrix)
     // This test constructs two different objects with the same matrix
     // This test examines the functionality of the constructor and
     // column_vector_matrix()
-    EXPECT_EQ(fcc_ptr->column_vector_matrix(), fcc2_ptr->column_vector_matrix());
+    EXPECT_EQ(fcc_ptr->column_vector_matrix(), fcc_copy_ptr->column_vector_matrix());
 }
 
 TEST_F(LatticeTest, BracketOperator)
@@ -53,15 +55,15 @@ TEST_F(LatticeTest, VectorAccess)
 }
 TEST_F(LatticeTest, LatticeEquals)
 {
-    Eigen::Matrix3d fcc3_matrix;
-    fcc3_matrix << 0.0, 1.5, 1.5, 1.5, 0.0, 1.5, 1.5, 1.5 + 1e-4, 0.0;
-    casmutils::xtal::Lattice fcc3_lat(fcc3_matrix);
+    Eigen::Matrix3d fcc_with_distortion_matrix;
+    fcc_with_distortion_matrix << 0.0, 1.5, 1.5, 1.5, 0.0, 1.5, 1.5, 1.5 + 1e-4, 0.0;
+    casmutils::xtal::Lattice fcc_with_distortion_lat(fcc_with_distortion_matrix);
     // This test checks the ability to determine if two lattices
     // are equivalent within numerical tolerance
     double tol = 1e-5;
-    casmutils::xtal::LatticeEquals_f equalizer(*fcc_ptr, tol);
-    EXPECT_TRUE(equalizer(*fcc2_ptr));
-    EXPECT_TRUE(!equalizer(fcc3_lat));
+    casmutils::xtal::LatticeEquals_f is_equal_to_fcc_lattice(*fcc_ptr, tol);
+    EXPECT_TRUE(is_equal_to_fcc_lattice(*fcc_copy_ptr));
+    EXPECT_TRUE(!is_equal_to_fcc_lattice(fcc_with_distortion_lat));
 }
 
 int main(int argc, char** argv)

--- a/tests/unit/casmutils/lattice.cpp
+++ b/tests/unit/casmutils/lattice.cpp
@@ -51,12 +51,17 @@ TEST_F(LatticeTest, VectorAccess)
     EXPECT_EQ(bcc_ptr->a().norm(), bcc_ptr->c().norm());
     EXPECT_TRUE((hcp_ptr->a().norm() - hcp_ptr->b().norm()) < 1e-5);
 }
-TEST_F(LatticeTest,LatticeEquals){
-	// This test checks the ability to determine if two lattices
-	// are equivalent within numerical tolerance
-	double tol=1e-5;
-	casmutils::xtal::LatticeEquals_f equalizer(*fcc_ptr,tol);
-	EXPECT_TRUE(equalizer(*fcc2_ptr));
+TEST_F(LatticeTest, LatticeEquals)
+{
+	Eigen::Matrix3d fcc3_matrix;
+	fcc3_matrix << 0.0, 1.5, 1.5, 1.5, 0.0, 1.5, 1.5, 1.5+1e-4, 0.0;
+	casmutils::xtal::Lattice fcc3_lat(fcc3_matrix);
+    // This test checks the ability to determine if two lattices
+    // are equivalent within numerical tolerance
+    double tol = 1e-5;
+    casmutils::xtal::LatticeEquals_f equalizer(*fcc_ptr, tol);
+    EXPECT_TRUE(equalizer(*fcc2_ptr));
+	EXPECT_TRUE(!equalizer(fcc3_lat));
 }
 
 int main(int argc, char** argv)

--- a/tests/unit/casmutils/lattice.cpp
+++ b/tests/unit/casmutils/lattice.cpp
@@ -49,7 +49,14 @@ TEST_F(LatticeTest, VectorAccess)
     // tests a(), b(), c()
     EXPECT_EQ(bcc_ptr->a().norm(), bcc_ptr->b().norm());
     EXPECT_EQ(bcc_ptr->a().norm(), bcc_ptr->c().norm());
-    EXPECT_EQ((hcp_ptr->a().norm() - hcp_ptr->b().norm()) < 1e-5, true);
+    EXPECT_TRUE((hcp_ptr->a().norm() - hcp_ptr->b().norm()) < 1e-5);
+}
+TEST_F(LatticeTest,LatticeEquals){
+	// This test checks the ability to determine if two lattices
+	// are equivalent within numerical tolerance
+	double tol=1e-5;
+	casmutils::xtal::LatticeEquals_f equalizer(*fcc_ptr,tol);
+	EXPECT_TRUE(equalizer(*fcc2_ptr));
 }
 
 int main(int argc, char** argv)

--- a/tests/unit/casmutils/lattice.cpp
+++ b/tests/unit/casmutils/lattice.cpp
@@ -9,11 +9,14 @@ protected:
     {
         Eigen::Matrix3d fcc_matrix;
         fcc_matrix << 0.0, 1.5, 1.5, 1.5, 0.0, 1.5, 1.5, 1.5, 0.0;
+
         fcc_ptr.reset(new rewrap::Lattice(fcc_matrix));
         fcc_copy_ptr.reset(new rewrap::Lattice(fcc_matrix));
+
         Eigen::Matrix3d bcc_matrix;
         bcc_matrix << -1.5, 1.5, 1.5, 1.5, -1.5, 1.5, 1.5, 1.5, -1.5;
         bcc_ptr.reset(new rewrap::Lattice(bcc_matrix));
+
         Eigen::Matrix3d hcp_matrix;
         hcp_matrix << -2.871, -1.4355, 0.0, 0.0, 2.486358934265, 0.0, 0.0, 0.0, 4.635;
         hcp_ptr.reset(new rewrap::Lattice(hcp_matrix));
@@ -30,15 +33,15 @@ protected:
 
 TEST_F(LatticeTest, ConstructandGetMatrix)
 {
-    // This test constructs two different objects with the same matrix
-    // This test examines the functionality of the constructor and
+    //  constructs two different objects with the same matrix
+    //  examines the functionality of the constructor and
     // column_vector_matrix()
     EXPECT_EQ(fcc_ptr->column_vector_matrix(), fcc_copy_ptr->column_vector_matrix());
 }
 
 TEST_F(LatticeTest, BracketOperator)
 {
-    // This test uses the bracket operator to check that the
+    //  uses the bracket operator to check that the
     // third vector of z oriented hcp is along the z direction
     auto unitvec = (*hcp_ptr)[2] / (*hcp_ptr)[2].norm();
     EXPECT_EQ(unitvec, Eigen::Vector3d(0, 0, 1));
@@ -46,7 +49,7 @@ TEST_F(LatticeTest, BracketOperator)
 
 TEST_F(LatticeTest, VectorAccess)
 {
-    // This test grabs the vectors of a bcc lattice and sees that
+    //  grabs the vectors of a bcc lattice and sees that
     // the lengths are the same. Does the same for a and b of hcp
     // tests a(), b(), c()
     EXPECT_EQ(bcc_ptr->a().norm(), bcc_ptr->b().norm());
@@ -58,12 +61,12 @@ TEST_F(LatticeTest, LatticeEquals)
     Eigen::Matrix3d fcc_with_distortion_matrix;
     fcc_with_distortion_matrix << 0.0, 1.5, 1.5, 1.5, 0.0, 1.5, 1.5, 1.5 + 1e-4, 0.0;
     casmutils::xtal::Lattice fcc_with_distortion_lat(fcc_with_distortion_matrix);
-    // This test checks the ability to determine if two lattices
+    //  checks the ability to determine if two lattices
     // are equivalent within numerical tolerance
     double tol = 1e-5;
     casmutils::xtal::LatticeEquals_f is_equal_to_fcc_lattice(*fcc_ptr, tol);
     EXPECT_TRUE(is_equal_to_fcc_lattice(*fcc_copy_ptr));
-    EXPECT_TRUE(!is_equal_to_fcc_lattice(fcc_with_distortion_lat));
+    EXPECT_FALSE(is_equal_to_fcc_lattice(fcc_with_distortion_lat));
 }
 
 int main(int argc, char** argv)

--- a/tests/unit/casmutils/lattice.cpp
+++ b/tests/unit/casmutils/lattice.cpp
@@ -53,15 +53,15 @@ TEST_F(LatticeTest, VectorAccess)
 }
 TEST_F(LatticeTest, LatticeEquals)
 {
-	Eigen::Matrix3d fcc3_matrix;
-	fcc3_matrix << 0.0, 1.5, 1.5, 1.5, 0.0, 1.5, 1.5, 1.5+1e-4, 0.0;
-	casmutils::xtal::Lattice fcc3_lat(fcc3_matrix);
+    Eigen::Matrix3d fcc3_matrix;
+    fcc3_matrix << 0.0, 1.5, 1.5, 1.5, 0.0, 1.5, 1.5, 1.5 + 1e-4, 0.0;
+    casmutils::xtal::Lattice fcc3_lat(fcc3_matrix);
     // This test checks the ability to determine if two lattices
     // are equivalent within numerical tolerance
     double tol = 1e-5;
     casmutils::xtal::LatticeEquals_f equalizer(*fcc_ptr, tol);
     EXPECT_TRUE(equalizer(*fcc2_ptr));
-	EXPECT_TRUE(!equalizer(fcc3_lat));
+    EXPECT_TRUE(!equalizer(fcc3_lat));
 }
 
 int main(int argc, char** argv)

--- a/tests/unit/casmutils/meta.cpp
+++ b/tests/unit/casmutils/meta.cpp
@@ -2,10 +2,11 @@
 #include <filesystem>
 #include <gtest/gtest.h>
 
-TEST(AutoToolsTest, InputFilePath) {
+TEST(AutoToolsTest, InputFilePath)
+{
     casmutils::fs::path input_files_path(casmutils::autotools::input_filesdir);
-    std::cout<<input_files_path<<std::endl;
-    EXPECT_TRUE(casmutils::fs::exists(input_files_path/"meta.txt"));
+    std::cout << input_files_path << std::endl;
+    EXPECT_TRUE(casmutils::fs::exists(input_files_path / "meta.txt"));
 }
 
 int main(int argc, char** argv)
@@ -13,4 +14,3 @@ int main(int argc, char** argv)
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
-

--- a/tests/unit/casmutils/site.cpp
+++ b/tests/unit/casmutils/site.cpp
@@ -14,7 +14,7 @@ protected:
         rewrap::Coordinate init_position(raw_coord);
         // store coordinate object for comparisons later
         init_pos_ptr.reset(new rewrap::Coordinate(raw_coord));
-
+        // Makes lithium and nickel sites with the same position
         lithium_site_ptr.reset(new rewrap::Site(init_position, "Li"));
         nickel_site_ptr.reset(new rewrap::Site(init_position, "Ni"));
         // store lattice for coordinate transforms
@@ -26,12 +26,13 @@ protected:
     std::unique_ptr<rewrap::Site> nickel_site_ptr;
 
     std::unique_ptr<rewrap::Coordinate> init_pos_ptr;
+
     std::unique_ptr<rewrap::Lattice> cubic_lattice_ptr;
 };
 
 TEST_F(SiteTest, Construct)
 {
-    // This test checks construction and the const accessors
+    // checks construction and the const accessors
     // to the cartesian position of the site and the
     // identity of the site.
     EXPECT_EQ(lithium_site_ptr->cart(), nickel_site_ptr->cart());
@@ -41,23 +42,23 @@ TEST_F(SiteTest, Construct)
 
 TEST_F(SiteTest, CoordCast)
 {
-    // This test checks the ability to cast a Site to a Coordinate
+    // checks the ability to cast a Site to a Coordinate
     EXPECT_EQ(rewrap::Coordinate(*lithium_site_ptr).cart(), init_pos_ptr->cart());
 };
 
 TEST_F(SiteTest, FracConversion)
 {
-    // This test checks the ability to get the fractional
+    // checks the ability to get the fractional
     // coordinates of a site with respect to a lattice
     EXPECT_EQ(lithium_site_ptr->frac(*cubic_lattice_ptr), Eigen::Vector3d(0.025, 0.05, 0.075));
 };
 TEST_F(SiteTest, SiteEquals)
 {
-    // This test checks the ability to determine the equality of sites
+    // checks the ability to determine the equality of sites using Functor
     double tol = 1e-5;
-    casmutils::xtal::SiteEquals_f equalizer(*lithium_site_ptr, tol);
-    EXPECT_TRUE(equalizer(*lithium_site_ptr));
-    EXPECT_TRUE(!equalizer(*nickel_site_ptr));
+    casmutils::xtal::SiteEquals_f is_equal_to_lithium_site(*lithium_site_ptr, tol);
+    EXPECT_TRUE(is_equal_to_lithium_site(*lithium_site_ptr));
+    EXPECT_TRUE(!is_equal_to_lithium_site(*nickel_site_ptr));
 };
 int main(int argc, char** argv)
 {

--- a/tests/unit/casmutils/site.cpp
+++ b/tests/unit/casmutils/site.cpp
@@ -58,7 +58,7 @@ TEST_F(SiteTest, SiteEquals)
     double tol = 1e-5;
     casmutils::xtal::SiteEquals_f is_equal_to_lithium_site(*lithium_site_ptr, tol);
     EXPECT_TRUE(is_equal_to_lithium_site(*lithium_site_ptr));
-    EXPECT_TRUE(!is_equal_to_lithium_site(*nickel_site_ptr));
+    EXPECT_FALSE(is_equal_to_lithium_site(*nickel_site_ptr));
 };
 int main(int argc, char** argv)
 {

--- a/tests/unit/casmutils/site.cpp
+++ b/tests/unit/casmutils/site.cpp
@@ -53,9 +53,9 @@ TEST_F(SiteTest, FracConversion)
 };
 TEST_F(SiteTest, SiteEquals)
 {
-    // This test checks the ability to determine the equality of sites 
-	double tol=1e-5;
-	casmutils::xtal::SiteEquals_f equalizer(*lithium_site_ptr,tol);
+    // This test checks the ability to determine the equality of sites
+    double tol = 1e-5;
+    casmutils::xtal::SiteEquals_f equalizer(*lithium_site_ptr, tol);
     EXPECT_TRUE(equalizer(*lithium_site_ptr));
     EXPECT_TRUE(!equalizer(*nickel_site_ptr));
 };

--- a/tests/unit/casmutils/site.cpp
+++ b/tests/unit/casmutils/site.cpp
@@ -51,7 +51,14 @@ TEST_F(SiteTest, FracConversion)
     // coordinates of a site with respect to a lattice
     EXPECT_EQ(lithium_site_ptr->frac(*cubic_lattice_ptr), Eigen::Vector3d(0.025, 0.05, 0.075));
 };
-
+TEST_F(SiteTest, SiteEquals)
+{
+    // This test checks the ability to determine the equality of sites 
+	double tol=1e-5;
+	casmutils::xtal::SiteEquals_f equalizer(*lithium_site_ptr,tol);
+    EXPECT_TRUE(equalizer(*lithium_site_ptr));
+    EXPECT_TRUE(!equalizer(*nickel_site_ptr));
+};
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/tests/unit/casmutils/structure.cpp
+++ b/tests/unit/casmutils/structure.cpp
@@ -53,12 +53,13 @@ TEST_F(StructureTest, ConstBasisAccess)
     // the basis of the structure
     EXPECT_TRUE((*site0_equal_ptr)(struc0_ptr->basis_sites()[0]));
 }
-TEST_F(StructureTest,ReadfromPOSCAR){
-	// This test checks the static function that reads 
-	// a POSCAR from a file and creates a casmutils::xtal::Structure
-	// from the contents
-	casmutils::fs::path pos_path("input_files/simple_cubic_Ni.vasp");
-	casmutils::xtal::Structure pos=casmutils::xtal::Structure::from_poscar(pos_path.string());
+TEST_F(StructureTest, ReadfromPOSCAR)
+{
+    // This test checks the static function that reads
+    // a POSCAR from a file and creates a casmutils::xtal::Structure
+    // from the contents
+    casmutils::fs::path pos_path("input_files/simple_cubic_Ni.vasp");
+    casmutils::xtal::Structure pos = casmutils::xtal::Structure::from_poscar(pos_path.string());
     EXPECT_TRUE((*lattice_equal_ptr)(pos.lattice()));
     EXPECT_TRUE((*site0_equal_ptr)(pos.basis_sites()[0]));
 }

--- a/tests/unit/casmutils/structure.cpp
+++ b/tests/unit/casmutils/structure.cpp
@@ -1,4 +1,5 @@
 // These are classes that structure depends on
+#include <casmutils/definitions.hpp>
 #include <casmutils/xtal/coordinate.hpp>
 #include <casmutils/xtal/lattice.hpp>
 #include <casmutils/xtal/site.hpp>
@@ -51,6 +52,15 @@ TEST_F(StructureTest, ConstBasisAccess)
     // This test checks the const accessor method to
     // the basis of the structure
     EXPECT_TRUE((*site0_equal_ptr)(struc0_ptr->basis_sites()[0]));
+}
+TEST_F(StructureTest,ReadfromPOSCAR){
+	// This test checks the static function that reads 
+	// a POSCAR from a file and creates a casmutils::xtal::Structure
+	// from the contents
+	casmutils::fs::path pos_path("input_files/simple_cubic_Ni.vasp");
+	casmutils::xtal::Structure pos=casmutils::xtal::Structure::from_poscar(pos_path.string());
+    EXPECT_TRUE((*lattice_equal_ptr)(pos.lattice()));
+    EXPECT_TRUE((*site0_equal_ptr)(pos.basis_sites()[0]));
 }
 TEST_F(StructureTest, SetLattice)
 {

--- a/tests/unit/casmutils/structure.cpp
+++ b/tests/unit/casmutils/structure.cpp
@@ -1,78 +1,78 @@
-//These are classes that structure depends on
+// These are classes that structure depends on
 #include <casmutils/xtal/coordinate.hpp>
-#include <casmutils/xtal/site.hpp>
 #include <casmutils/xtal/lattice.hpp>
+#include <casmutils/xtal/site.hpp>
 #include <gtest/gtest.h>
-//This file tests the functions in:
+// This file tests the functions in:
 #include <casmutils/xtal/structure.hpp>
 class StructureTest : public testing::Test
 {
 protected:
     void SetUp() override
     {
-		Eigen::Matrix3d cubic_lat_mat;
-		cubic_lat_mat << 2,0,0,
-					     0,2,0,
-						 0,0,2;
-		cubic_lat_ptr.reset(new casmutils::xtal::Lattice(cubic_lat_mat));
-		double_cubic_lat_ptr.reset(new casmutils::xtal::Lattice(2*cubic_lat_mat));
-		lattice_equal_ptr.reset(new casmutils::xtal::LatticeEquals_f(*cubic_lat_ptr,tol));
-		casmutils::xtal::Site site0(casmutils::xtal::Coordinate(Eigen::Vector3d(0,0,1)),"Ni");
-		casmutils::xtal::Site site1(casmutils::xtal::Coordinate(Eigen::Vector3d(0,0,2)),"Ni");
-		basis0_ptr.reset(new std::vector<casmutils::xtal::Site>({site0}));
-		basis1_ptr.reset(new std::vector<casmutils::xtal::Site>({site1}));
-		struc0_ptr.reset(new casmutils::xtal::Structure(*cubic_lat_ptr,*basis0_ptr));
-		site0_equal_ptr.reset(new casmutils::xtal::SiteEquals_f((*basis0_ptr)[0],tol));
-		site1_equal_ptr.reset(new casmutils::xtal::SiteEquals_f((*basis1_ptr)[0],tol));
-		//struc1_ptr.reset(new casmutils::xtal::Structure(*cubic_lat_ptr,*basis0_ptr));
-		using CASM::CART;
-
+        Eigen::Matrix3d cubic_lat_mat;
+        cubic_lat_mat << 2, 0, 0, 0, 2, 0, 0, 0, 2;
+        cubic_lat_ptr.reset(new casmutils::xtal::Lattice(cubic_lat_mat));
+        double_cubic_lat_ptr.reset(new casmutils::xtal::Lattice(2 * cubic_lat_mat));
+        lattice_equal_ptr.reset(new casmutils::xtal::LatticeEquals_f(*cubic_lat_ptr, tol));
+        casmutils::xtal::Site site0(casmutils::xtal::Coordinate(Eigen::Vector3d(0, 0, 1)), "Ni");
+        casmutils::xtal::Site site1(casmutils::xtal::Coordinate(Eigen::Vector3d(0, 0, 2)), "Ni");
+        basis0_ptr.reset(new std::vector<casmutils::xtal::Site>({site0}));
+        basis1_ptr.reset(new std::vector<casmutils::xtal::Site>({site1}));
+        struc0_ptr.reset(new casmutils::xtal::Structure(*cubic_lat_ptr, *basis0_ptr));
+        site0_equal_ptr.reset(new casmutils::xtal::SiteEquals_f((*basis0_ptr)[0], tol));
+        site1_equal_ptr.reset(new casmutils::xtal::SiteEquals_f((*basis1_ptr)[0], tol));
+        // struc1_ptr.reset(new casmutils::xtal::Structure(*cubic_lat_ptr,*basis0_ptr));
+        using CASM::CART;
     }
 
     // Use unique pointers because Structure has no default constructor
     std::unique_ptr<casmutils::xtal::Structure> struc0_ptr;
-    //std::unique_ptr<casmutils::xtal::Structure> struc1_ptr;
+    // std::unique_ptr<casmutils::xtal::Structure> struc1_ptr;
     std::unique_ptr<casmutils::xtal::Lattice> cubic_lat_ptr;
     std::unique_ptr<casmutils::xtal::Lattice> double_cubic_lat_ptr;
-	std::unique_ptr<casmutils::xtal::LatticeEquals_f> lattice_equal_ptr;
+    std::unique_ptr<casmutils::xtal::LatticeEquals_f> lattice_equal_ptr;
     std::unique_ptr<std::vector<casmutils::xtal::Site>> basis0_ptr;
     std::unique_ptr<std::vector<casmutils::xtal::Site>> basis1_ptr;
-	std::unique_ptr<casmutils::xtal::SiteEquals_f> site0_equal_ptr;
-	std::unique_ptr<casmutils::xtal::SiteEquals_f> site1_equal_ptr;
-	double tol = 1e-5;
+    std::unique_ptr<casmutils::xtal::SiteEquals_f> site0_equal_ptr;
+    std::unique_ptr<casmutils::xtal::SiteEquals_f> site1_equal_ptr;
+    double tol = 1e-5;
 };
 
-TEST_F(StructureTest, ConstructandLatAccess){
-	//This test checks to see if Structure can be constructed 
-	//and has the lattice that was given associated with it. 
-	EXPECT_TRUE((*lattice_equal_ptr)(struc0_ptr->lattice()));
+TEST_F(StructureTest, ConstructandLatAccess)
+{
+    // This test checks to see if Structure can be constructed
+    // and has the lattice that was given associated with it.
+    EXPECT_TRUE((*lattice_equal_ptr)(struc0_ptr->lattice()));
 }
 
-TEST_F(StructureTest, ConstBasisAccess){
-	//This test checks the const accessor method to 
-	//the basis of the structure
-	EXPECT_TRUE((*site0_equal_ptr)(struc0_ptr->basis_sites()[0]));
+TEST_F(StructureTest, ConstBasisAccess)
+{
+    // This test checks the const accessor method to
+    // the basis of the structure
+    EXPECT_TRUE((*site0_equal_ptr)(struc0_ptr->basis_sites()[0]));
 }
-TEST_F(StructureTest, SetLattice){
-	//This test checks the set lattice function
-	//in one instance keeping the fractional coordinates
-	//and in one instance keeping the cartesian coordinates
-	
-	//CARTESIAN CALL SHOULD NOT CHANGE BASIS	
-	const casmutils::xtal::Structure &struc0ref= *struc0_ptr;
-	casmutils::xtal::Structure new_struc=struc0ref.set_lattice(*double_cubic_lat_ptr,casmutils::xtal::CART);
-	//Const call to set_lattice doesn't mutate original
-	EXPECT_TRUE((*site0_equal_ptr)(struc0ref.basis_sites()[0]));
-	EXPECT_TRUE((*lattice_equal_ptr)(struc0ref.lattice()));
-	//Const call to set_lattice does return new structure
-	EXPECT_TRUE((*site0_equal_ptr)(new_struc.basis_sites()[0]));
-	EXPECT_TRUE(!(*lattice_equal_ptr)(new_struc.lattice()));
-	///FRACTIONAL CALL SHOULD CHANGE BASIS
-	struc0_ptr->set_lattice(*double_cubic_lat_ptr,casmutils::xtal::FRAC);
-	///Basis should now be different (site0 transforms to site1 from test frame)
-	EXPECT_TRUE((*site1_equal_ptr)(struc0_ptr->basis_sites()[0]));
-	///Lattice should be different
-	EXPECT_TRUE(!(*lattice_equal_ptr)(struc0_ptr->lattice()));
+TEST_F(StructureTest, SetLattice)
+{
+    // This test checks the set lattice function
+    // in one instance keeping the fractional coordinates
+    // and in one instance keeping the cartesian coordinates
+
+    // CARTESIAN CALL SHOULD NOT CHANGE BASIS
+    const casmutils::xtal::Structure& struc0ref = *struc0_ptr;
+    casmutils::xtal::Structure new_struc = struc0ref.set_lattice(*double_cubic_lat_ptr, casmutils::xtal::CART);
+    // Const call to set_lattice doesn't mutate original
+    EXPECT_TRUE((*site0_equal_ptr)(struc0ref.basis_sites()[0]));
+    EXPECT_TRUE((*lattice_equal_ptr)(struc0ref.lattice()));
+    // Const call to set_lattice does return new structure
+    EXPECT_TRUE((*site0_equal_ptr)(new_struc.basis_sites()[0]));
+    EXPECT_TRUE(!(*lattice_equal_ptr)(new_struc.lattice()));
+    /// FRACTIONAL CALL SHOULD CHANGE BASIS
+    struc0_ptr->set_lattice(*double_cubic_lat_ptr, casmutils::xtal::FRAC);
+    /// Basis should now be different (site0 transforms to site1 from test frame)
+    EXPECT_TRUE((*site1_equal_ptr)(struc0_ptr->basis_sites()[0]));
+    /// Lattice should be different
+    EXPECT_TRUE(!(*lattice_equal_ptr)(struc0_ptr->lattice()));
 }
 
 int main(int argc, char** argv)

--- a/tests/unit/casmutils/structure.cpp
+++ b/tests/unit/casmutils/structure.cpp
@@ -1,4 +1,5 @@
 // These are classes that structure depends on
+#include "../../autotools.hh"
 #include <casmutils/definitions.hpp>
 #include <casmutils/xtal/coordinate.hpp>
 #include <casmutils/xtal/lattice.hpp>
@@ -58,9 +59,10 @@ TEST_F(StructureTest, ReadfromPOSCAR)
     // This test checks the static function that reads
     // a POSCAR from a file and creates a casmutils::xtal::Structure
     // from the contents
-    casmutils::fs::path pos_path("input_files/simple_cubic_Ni.vasp");
-    casmutils::xtal::Structure pos = casmutils::xtal::Structure::from_poscar(pos_path.string());
+    casmutils::fs::path pos_path(casmutils::autotools::input_filesdir / "simple_cubic_Ni.vasp");
+    casmutils::xtal::Structure pos = casmutils::xtal::Structure::from_poscar(pos_path);
     EXPECT_TRUE((*lattice_equal_ptr)(pos.lattice()));
+    std::cout << pos.basis_sites()[0].cart() << std::endl;
     EXPECT_TRUE((*site0_equal_ptr)(pos.basis_sites()[0]));
 }
 TEST_F(StructureTest, SetLattice)

--- a/tests/unit/casmutils/structure.cpp
+++ b/tests/unit/casmutils/structure.cpp
@@ -68,14 +68,14 @@ TEST_F(StructureTest, ReadfromPOSCAR)
 }
 TEST_F(StructureTest, SetLatticeFrac)
 {
-    /// FRACTIONAL CALL SHOULD CHANGE BASIS
+    // FRACTIONAL CALL SHOULD CHANGE BASIS
     cubic_Ni_struc_ptr->set_lattice(*big_cubic_lat_ptr, casmutils::xtal::FRAC);
-    /// Basis should now be different (site0 transforms to site1 from test frame)
+    // Basis should now be different (site0 transforms to site1 from test frame)
     EXPECT_TRUE(casmutils::is_equal<casmutils::xtal::SiteEquals_f>((*basis1_ptr)[0],
                                                                    cubic_Ni_struc_ptr->basis_sites()[0], tol));
-    /// Lattice should be different
-    EXPECT_TRUE(
-        !casmutils::is_equal<casmutils::xtal::LatticeEquals_f>(*cubic_lat_ptr, cubic_Ni_struc_ptr->lattice(), tol));
+    // Lattice should be different
+    EXPECT_FALSE(
+        casmutils::is_equal<casmutils::xtal::LatticeEquals_f>(*cubic_lat_ptr, cubic_Ni_struc_ptr->lattice(), tol));
 }
 TEST_F(StructureTest, ConstSetLatticeCart)
 {
@@ -93,7 +93,7 @@ TEST_F(StructureTest, ConstSetLatticeCart)
         casmutils::is_equal<casmutils::xtal::LatticeEquals_f>(*cubic_lat_ptr, cubic_Ni_strucref.lattice(), tol));
     // Const call to set_lattice does return new structure
     EXPECT_TRUE(casmutils::is_equal<casmutils::xtal::SiteEquals_f>((*basis0_ptr)[0], new_struc.basis_sites()[0], tol));
-    EXPECT_TRUE(!casmutils::is_equal<casmutils::xtal::LatticeEquals_f>(*cubic_lat_ptr, new_struc.lattice(), tol));
+    EXPECT_FALSE(casmutils::is_equal<casmutils::xtal::LatticeEquals_f>(*cubic_lat_ptr, new_struc.lattice(), tol));
 }
 int main(int argc, char** argv)
 {

--- a/tests/unit/casmutils/structure.cpp
+++ b/tests/unit/casmutils/structure.cpp
@@ -1,12 +1,14 @@
 // These are classes that structure depends on
 #include "../../autotools.hh"
 #include <casmutils/definitions.hpp>
+#include <casmutils/misc.hpp>
 #include <casmutils/xtal/coordinate.hpp>
 #include <casmutils/xtal/lattice.hpp>
 #include <casmutils/xtal/site.hpp>
 #include <gtest/gtest.h>
 // This file tests the functions in:
 #include <casmutils/xtal/structure.hpp>
+
 class StructureTest : public testing::Test
 {
 protected:
@@ -14,78 +16,81 @@ protected:
     {
         Eigen::Matrix3d cubic_lat_mat;
         cubic_lat_mat << 2, 0, 0, 0, 2, 0, 0, 0, 2;
+        // Make two cubic lattices
         cubic_lat_ptr.reset(new casmutils::xtal::Lattice(cubic_lat_mat));
-        double_cubic_lat_ptr.reset(new casmutils::xtal::Lattice(2 * cubic_lat_mat));
-        lattice_equal_ptr.reset(new casmutils::xtal::LatticeEquals_f(*cubic_lat_ptr, tol));
+        big_cubic_lat_ptr.reset(new casmutils::xtal::Lattice(2 * cubic_lat_mat));
+        // Make two Ni sites at different locations along z axis
         casmutils::xtal::Site site0(casmutils::xtal::Coordinate(Eigen::Vector3d(0, 0, 1)), "Ni");
         casmutils::xtal::Site site1(casmutils::xtal::Coordinate(Eigen::Vector3d(0, 0, 2)), "Ni");
+        // Make bases out of each site
         basis0_ptr.reset(new std::vector<casmutils::xtal::Site>({site0}));
         basis1_ptr.reset(new std::vector<casmutils::xtal::Site>({site1}));
-        struc0_ptr.reset(new casmutils::xtal::Structure(*cubic_lat_ptr, *basis0_ptr));
-        site0_equal_ptr.reset(new casmutils::xtal::SiteEquals_f((*basis0_ptr)[0], tol));
-        site1_equal_ptr.reset(new casmutils::xtal::SiteEquals_f((*basis1_ptr)[0], tol));
-        // struc1_ptr.reset(new casmutils::xtal::Structure(*cubic_lat_ptr,*basis0_ptr));
+        // Make cubic structure
+        cubic_Ni_struc_ptr.reset(new casmutils::xtal::Structure(*cubic_lat_ptr, *basis0_ptr));
         using CASM::CART;
     }
 
     // Use unique pointers because Structure has no default constructor
-    std::unique_ptr<casmutils::xtal::Structure> struc0_ptr;
-    // std::unique_ptr<casmutils::xtal::Structure> struc1_ptr;
+    std::unique_ptr<casmutils::xtal::Structure> cubic_Ni_struc_ptr;
+
     std::unique_ptr<casmutils::xtal::Lattice> cubic_lat_ptr;
-    std::unique_ptr<casmutils::xtal::Lattice> double_cubic_lat_ptr;
-    std::unique_ptr<casmutils::xtal::LatticeEquals_f> lattice_equal_ptr;
+    std::unique_ptr<casmutils::xtal::Lattice> big_cubic_lat_ptr;
+
     std::unique_ptr<std::vector<casmutils::xtal::Site>> basis0_ptr;
     std::unique_ptr<std::vector<casmutils::xtal::Site>> basis1_ptr;
-    std::unique_ptr<casmutils::xtal::SiteEquals_f> site0_equal_ptr;
-    std::unique_ptr<casmutils::xtal::SiteEquals_f> site1_equal_ptr;
     double tol = 1e-5;
 };
 
 TEST_F(StructureTest, ConstructandLatAccess)
 {
-    // This test checks to see if Structure can be constructed
+    //  checks to see if Structure can be constructed
     // and has the lattice that was given associated with it.
-    EXPECT_TRUE((*lattice_equal_ptr)(struc0_ptr->lattice()));
+    EXPECT_TRUE(
+        casmutils::is_equal<casmutils::xtal::LatticeEquals_f>(*cubic_lat_ptr, cubic_Ni_struc_ptr->lattice(), tol));
 }
 
 TEST_F(StructureTest, ConstBasisAccess)
 {
-    // This test checks the const accessor method to
+    //  checks the const accessor method to
     // the basis of the structure
-    EXPECT_TRUE((*site0_equal_ptr)(struc0_ptr->basis_sites()[0]));
+    EXPECT_TRUE(casmutils::is_equal<casmutils::xtal::SiteEquals_f>((*basis0_ptr)[0],
+                                                                   cubic_Ni_struc_ptr->basis_sites()[0], tol));
 }
 TEST_F(StructureTest, ReadfromPOSCAR)
 {
-    // This test checks the static function that reads
+    //  checks the static function that reads
     // a POSCAR from a file and creates a casmutils::xtal::Structure
     // from the contents
     casmutils::fs::path pos_path(casmutils::autotools::input_filesdir / "simple_cubic_Ni.vasp");
     casmutils::xtal::Structure pos = casmutils::xtal::Structure::from_poscar(pos_path);
-    EXPECT_TRUE((*lattice_equal_ptr)(pos.lattice()));
-    std::cout << pos.basis_sites()[0].cart() << std::endl;
-    EXPECT_TRUE((*site0_equal_ptr)(pos.basis_sites()[0]));
+    EXPECT_TRUE(casmutils::is_equal<casmutils::xtal::LatticeEquals_f>(*cubic_lat_ptr, pos.lattice(), tol));
+    EXPECT_TRUE(casmutils::is_equal<casmutils::xtal::SiteEquals_f>((*basis0_ptr)[0], pos.basis_sites()[0], tol));
 }
 TEST_F(StructureTest, SetLattice)
 {
-    // This test checks the set lattice function
+    //  checks the set lattice function
     // in one instance keeping the fractional coordinates
     // and in one instance keeping the cartesian coordinates
 
     // CARTESIAN CALL SHOULD NOT CHANGE BASIS
-    const casmutils::xtal::Structure& struc0ref = *struc0_ptr;
-    casmutils::xtal::Structure new_struc = struc0ref.set_lattice(*double_cubic_lat_ptr, casmutils::xtal::CART);
+    const casmutils::xtal::Structure& cubic_Ni_strucref = *cubic_Ni_struc_ptr;
+    casmutils::xtal::Structure new_struc = cubic_Ni_strucref.set_lattice(*big_cubic_lat_ptr, casmutils::xtal::CART);
     // Const call to set_lattice doesn't mutate original
-    EXPECT_TRUE((*site0_equal_ptr)(struc0ref.basis_sites()[0]));
-    EXPECT_TRUE((*lattice_equal_ptr)(struc0ref.lattice()));
+    EXPECT_TRUE(
+        casmutils::is_equal<casmutils::xtal::SiteEquals_f>((*basis0_ptr)[0], cubic_Ni_strucref.basis_sites()[0], tol));
+    EXPECT_TRUE(
+        casmutils::is_equal<casmutils::xtal::LatticeEquals_f>(*cubic_lat_ptr, cubic_Ni_strucref.lattice(), tol));
     // Const call to set_lattice does return new structure
-    EXPECT_TRUE((*site0_equal_ptr)(new_struc.basis_sites()[0]));
-    EXPECT_TRUE(!(*lattice_equal_ptr)(new_struc.lattice()));
+    EXPECT_TRUE(casmutils::is_equal<casmutils::xtal::SiteEquals_f>((*basis0_ptr)[0], new_struc.basis_sites()[0], tol));
+    EXPECT_TRUE(!casmutils::is_equal<casmutils::xtal::LatticeEquals_f>(*cubic_lat_ptr, new_struc.lattice(), tol));
     /// FRACTIONAL CALL SHOULD CHANGE BASIS
-    struc0_ptr->set_lattice(*double_cubic_lat_ptr, casmutils::xtal::FRAC);
+    cubic_Ni_struc_ptr->set_lattice(*big_cubic_lat_ptr, casmutils::xtal::FRAC);
     /// Basis should now be different (site0 transforms to site1 from test frame)
-    EXPECT_TRUE((*site1_equal_ptr)(struc0_ptr->basis_sites()[0]));
+    EXPECT_TRUE(casmutils::is_equal<casmutils::xtal::SiteEquals_f>((*basis1_ptr)[0],
+                                                                   cubic_Ni_struc_ptr->basis_sites()[0], tol));
     /// Lattice should be different
-    EXPECT_TRUE(!(*lattice_equal_ptr)(struc0_ptr->lattice()));
+    EXPECT_TRUE(
+        !casmutils::is_equal<casmutils::xtal::LatticeEquals_f>(*cubic_lat_ptr, cubic_Ni_struc_ptr->lattice(), tol));
 }
 
 int main(int argc, char** argv)

--- a/tests/unit/casmutils/structure.cpp
+++ b/tests/unit/casmutils/structure.cpp
@@ -1,4 +1,79 @@
+//These are classes that structure depends on
+#include <casmutils/xtal/coordinate.hpp>
+#include <casmutils/xtal/site.hpp>
+#include <casmutils/xtal/lattice.hpp>
 #include <gtest/gtest.h>
+//This file tests the functions in:
+#include <casmutils/xtal/structure.hpp>
+class StructureTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+		Eigen::Matrix3d cubic_lat_mat;
+		cubic_lat_mat << 2,0,0,
+					     0,2,0,
+						 0,0,2;
+		cubic_lat_ptr.reset(new casmutils::xtal::Lattice(cubic_lat_mat));
+		double_cubic_lat_ptr.reset(new casmutils::xtal::Lattice(2*cubic_lat_mat));
+		lattice_equal_ptr.reset(new casmutils::xtal::LatticeEquals_f(*cubic_lat_ptr,tol));
+		casmutils::xtal::Site site0(casmutils::xtal::Coordinate(Eigen::Vector3d(0,0,1)),"Ni");
+		casmutils::xtal::Site site1(casmutils::xtal::Coordinate(Eigen::Vector3d(0,0,2)),"Ni");
+		basis0_ptr.reset(new std::vector<casmutils::xtal::Site>({site0}));
+		basis1_ptr.reset(new std::vector<casmutils::xtal::Site>({site1}));
+		struc0_ptr.reset(new casmutils::xtal::Structure(*cubic_lat_ptr,*basis0_ptr));
+		site0_equal_ptr.reset(new casmutils::xtal::SiteEquals_f((*basis0_ptr)[0],tol));
+		site1_equal_ptr.reset(new casmutils::xtal::SiteEquals_f((*basis1_ptr)[0],tol));
+		//struc1_ptr.reset(new casmutils::xtal::Structure(*cubic_lat_ptr,*basis0_ptr));
+		using CASM::CART;
+
+    }
+
+    // Use unique pointers because Structure has no default constructor
+    std::unique_ptr<casmutils::xtal::Structure> struc0_ptr;
+    //std::unique_ptr<casmutils::xtal::Structure> struc1_ptr;
+    std::unique_ptr<casmutils::xtal::Lattice> cubic_lat_ptr;
+    std::unique_ptr<casmutils::xtal::Lattice> double_cubic_lat_ptr;
+	std::unique_ptr<casmutils::xtal::LatticeEquals_f> lattice_equal_ptr;
+    std::unique_ptr<std::vector<casmutils::xtal::Site>> basis0_ptr;
+    std::unique_ptr<std::vector<casmutils::xtal::Site>> basis1_ptr;
+	std::unique_ptr<casmutils::xtal::SiteEquals_f> site0_equal_ptr;
+	std::unique_ptr<casmutils::xtal::SiteEquals_f> site1_equal_ptr;
+	double tol = 1e-5;
+};
+
+TEST_F(StructureTest, ConstructandLatAccess){
+	//This test checks to see if Structure can be constructed 
+	//and has the lattice that was given associated with it. 
+	EXPECT_TRUE((*lattice_equal_ptr)(struc0_ptr->lattice()));
+}
+
+TEST_F(StructureTest, ConstBasisAccess){
+	//This test checks the const accessor method to 
+	//the basis of the structure
+	EXPECT_TRUE((*site0_equal_ptr)(struc0_ptr->basis_sites()[0]));
+}
+TEST_F(StructureTest, SetLattice){
+	//This test checks the set lattice function
+	//in one instance keeping the fractional coordinates
+	//and in one instance keeping the cartesian coordinates
+	
+	//CARTESIAN CALL SHOULD NOT CHANGE BASIS	
+	const casmutils::xtal::Structure &struc0ref= *struc0_ptr;
+	casmutils::xtal::Structure new_struc=struc0ref.set_lattice(*double_cubic_lat_ptr,casmutils::xtal::CART);
+	//Const call to set_lattice doesn't mutate original
+	EXPECT_TRUE((*site0_equal_ptr)(struc0ref.basis_sites()[0]));
+	EXPECT_TRUE((*lattice_equal_ptr)(struc0ref.lattice()));
+	//Const call to set_lattice does return new structure
+	EXPECT_TRUE((*site0_equal_ptr)(new_struc.basis_sites()[0]));
+	EXPECT_TRUE(!(*lattice_equal_ptr)(new_struc.lattice()));
+	///FRACTIONAL CALL SHOULD CHANGE BASIS
+	struc0_ptr->set_lattice(*double_cubic_lat_ptr,casmutils::xtal::FRAC);
+	///Basis should now be different (site0 transforms to site1 from test frame)
+	EXPECT_TRUE((*site1_equal_ptr)(struc0_ptr->basis_sites()[0]));
+	///Lattice should be different
+	EXPECT_TRUE(!(*lattice_equal_ptr)(struc0_ptr->lattice()));
+}
 
 int main(int argc, char** argv)
 {

--- a/tests/unit/casmutils/structure.cpp
+++ b/tests/unit/casmutils/structure.cpp
@@ -66,7 +66,18 @@ TEST_F(StructureTest, ReadfromPOSCAR)
     EXPECT_TRUE(casmutils::is_equal<casmutils::xtal::LatticeEquals_f>(*cubic_lat_ptr, pos.lattice(), tol));
     EXPECT_TRUE(casmutils::is_equal<casmutils::xtal::SiteEquals_f>((*basis0_ptr)[0], pos.basis_sites()[0], tol));
 }
-TEST_F(StructureTest, SetLattice)
+TEST_F(StructureTest, SetLatticeFrac)
+{
+    /// FRACTIONAL CALL SHOULD CHANGE BASIS
+    cubic_Ni_struc_ptr->set_lattice(*big_cubic_lat_ptr, casmutils::xtal::FRAC);
+    /// Basis should now be different (site0 transforms to site1 from test frame)
+    EXPECT_TRUE(casmutils::is_equal<casmutils::xtal::SiteEquals_f>((*basis1_ptr)[0],
+                                                                   cubic_Ni_struc_ptr->basis_sites()[0], tol));
+    /// Lattice should be different
+    EXPECT_TRUE(
+        !casmutils::is_equal<casmutils::xtal::LatticeEquals_f>(*cubic_lat_ptr, cubic_Ni_struc_ptr->lattice(), tol));
+}
+TEST_F(StructureTest, ConstSetLatticeCart)
 {
     //  checks the set lattice function
     // in one instance keeping the fractional coordinates
@@ -83,16 +94,7 @@ TEST_F(StructureTest, SetLattice)
     // Const call to set_lattice does return new structure
     EXPECT_TRUE(casmutils::is_equal<casmutils::xtal::SiteEquals_f>((*basis0_ptr)[0], new_struc.basis_sites()[0], tol));
     EXPECT_TRUE(!casmutils::is_equal<casmutils::xtal::LatticeEquals_f>(*cubic_lat_ptr, new_struc.lattice(), tol));
-    /// FRACTIONAL CALL SHOULD CHANGE BASIS
-    cubic_Ni_struc_ptr->set_lattice(*big_cubic_lat_ptr, casmutils::xtal::FRAC);
-    /// Basis should now be different (site0 transforms to site1 from test frame)
-    EXPECT_TRUE(casmutils::is_equal<casmutils::xtal::SiteEquals_f>((*basis1_ptr)[0],
-                                                                   cubic_Ni_struc_ptr->basis_sites()[0], tol));
-    /// Lattice should be different
-    EXPECT_TRUE(
-        !casmutils::is_equal<casmutils::xtal::LatticeEquals_f>(*cubic_lat_ptr, cubic_Ni_struc_ptr->lattice(), tol));
 }
-
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Wrote tests for casmutils::xtal::structure.
Tests for Construction, Const accessors, set_lattice (both const and non const versions), and from_poscar
This branch builds on 0.4.X_transition_comparators, so if you pull this in you can ignore the other. 
