### PR TITLE
Pybinds for xtal::Site

### DIFF
--- a/lib-py/casmutils/xtal/Makemodule.am
+++ b/lib-py/casmutils/xtal/Makemodule.am
@@ -6,7 +6,7 @@ xtalpy_PYTHON=\
 			  lib-py/casmutils/xtal/coordinate.py\
 			  lib-py/casmutils/xtal/lattice.py\
 			  lib-py/casmutils/xtal/site.py\
-			  lib-py/casmutils/xtal/globalvar.py\
+			  lib-py/casmutils/xtal/globaldef.py\
 			  lib-py/casmutils/xtal/xtal.py
 
 xtalpy_LTLIBRARIES=\

--- a/lib-py/casmutils/xtal/Makemodule.am
+++ b/lib-py/casmutils/xtal/Makemodule.am
@@ -5,6 +5,7 @@ xtalpy_PYTHON=\
 			  lib-py/casmutils/xtal/single_block_wadsley_roth.py\
 			  lib-py/casmutils/xtal/coordinate.py\
 			  lib-py/casmutils/xtal/lattice.py\
+			  lib-py/casmutils/xtal/site.py\
 			  lib-py/casmutils/xtal/xtal.py
 
 xtalpy_LTLIBRARIES=\

--- a/lib-py/casmutils/xtal/Makemodule.am
+++ b/lib-py/casmutils/xtal/Makemodule.am
@@ -6,6 +6,7 @@ xtalpy_PYTHON=\
 			  lib-py/casmutils/xtal/coordinate.py\
 			  lib-py/casmutils/xtal/lattice.py\
 			  lib-py/casmutils/xtal/site.py\
+			  lib-py/casmutils/xtal/globalvar.py\
 			  lib-py/casmutils/xtal/xtal.py
 
 xtalpy_LTLIBRARIES=\

--- a/lib-py/casmutils/xtal/_xtal/site-py.cxx
+++ b/lib-py/casmutils/xtal/_xtal/site-py.cxx
@@ -18,7 +18,7 @@ namespace Site
 std::string __str__(const xtal::Site& printable)
 {
     std::ostringstream sstream;
-    throw except::NotImplemented();
+    sstream << "Coordinates of site (in Cartesian): " << printable.cart() << "Label of atom at site: " << printable.label();
     return sstream.str();
 }
 } // namespace Site

--- a/lib-py/casmutils/xtal/_xtal/site-py.cxx
+++ b/lib-py/casmutils/xtal/_xtal/site-py.cxx
@@ -18,7 +18,7 @@ namespace Site
 std::string __str__(const xtal::Site& printable)
 {
     std::ostringstream sstream;
-    sstream << "Coordinates of site (in Cartesian): " << printable.cart() << "Label of atom at site: " << printable.label();
+    sstream << printable.cart() << printable.label();
     return sstream.str();
 }
 } // namespace Site

--- a/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
+++ b/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
@@ -77,9 +77,16 @@ PYBIND11_MODULE(_xtal, m)
             .def(init<const xtal::Coordinate&, const std::string&>())
             .def("__str__", __str__)
             .def("cart", &xtal::Site::cart)
-            .def("frac", &xtal::Site::frac);
+            .def("frac", &xtal::Site::frac)
+            .def("label", &xtal::Site::label);
     }
-
+    
+    {
+        class_<xtal::SiteEquals_f>(m, "SiteEquals_f")
+            .def(init<xtal::Site, double())
+            .def("__call__", &xtal::SiteEquals_f::operator());
+    }
+    
     {
         using namespace wrappy::RockSaltToggler;
         typedef enumeration::RockSaltOctahedraToggler RSOT;

--- a/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
+++ b/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
@@ -76,9 +76,9 @@ PYBIND11_MODULE(_xtal, m)
             .def(init<const Eigen::Vector3d&, const std::string&>())
             .def(init<const xtal::Coordinate&, const std::string&>())
             .def("__str__", __str__)
-            .def("cart", &xtal::Site::cart)
-            .def("frac", &xtal::Site::frac)
-            .def("label", &xtal::Site::label);
+            .def("_cart_const", &xtal::Site::cart)
+            .def("_frac_const", &xtal::Site::frac)
+            .def("_label_const", &xtal::Site::label);
     }
     
     {

--- a/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
+++ b/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
@@ -83,7 +83,7 @@ PYBIND11_MODULE(_xtal, m)
     
     {
         class_<xtal::SiteEquals_f>(m, "SiteEquals_f")
-            .def(init<xtal::Site, double())
+            .def(init<xtal::Site, double>())
             .def("__call__", &xtal::SiteEquals_f::operator());
     }
     

--- a/lib-py/casmutils/xtal/coordinate.py
+++ b/lib-py/casmutils/xtal/coordinate.py
@@ -15,8 +15,7 @@ class Equals:
         tol : double
 
         """
-        self.ref_coordinate = ref_coordinate
-        self.tol = tol
+        self.CoordinateEquals_f = _xtal.CoordinateEquals_f(ref_coordinate._pybind_value, tol)
 
     def __call__(self, other):
         """Overloading () operator
@@ -30,7 +29,6 @@ class Equals:
         bool
 
         """
-        self.CoordinateEquals_f = _xtal.CoordinateEquals_f(self.ref_coordinate._pybind_value, self.tol)
         return self.CoordinateEquals_f(other._pybind_value)
 
 class _Coordinate:

--- a/lib-py/casmutils/xtal/coordinate.py
+++ b/lib-py/casmutils/xtal/coordinate.py
@@ -1,5 +1,5 @@
 from . import _xtal
-from . import globalvar
+from . import globaldef
 
 Equals=_xtal.CoordinateEquals_f
 
@@ -113,7 +113,7 @@ class _Coordinate:
 
         """
         if hasattr(self,'_equals') is False:
-            self._equals=Equals(self._pybind_value,globalvar.tol)
+            self._equals=Equals(self._pybind_value,globaldef.tol)
 
         return self._equals(other._pybind_value)
 

--- a/lib-py/casmutils/xtal/coordinate.py
+++ b/lib-py/casmutils/xtal/coordinate.py
@@ -1,4 +1,5 @@
 from . import _xtal
+from . import globalvar
 
 Equals=_xtal.CoordinateEquals_f
 
@@ -6,9 +7,6 @@ class _Coordinate:
 
     """Base class for both mutable and immutable Coordinate classes.
     Defines the functions that should be common for both."""
-
-    """Tolerance"""
-    tol = 1e-5
 
     def __init__(self, coord):
         """create an instance of _xtal.Coordinate
@@ -115,7 +113,7 @@ class _Coordinate:
 
         """
         if hasattr(self,'_equals') is False:
-            self._equals=Equals(self._pybind_value,self.tol)
+            self._equals=Equals(self._pybind_value,globalvar.tol)
 
         return self._equals(other._pybind_value)
 

--- a/lib-py/casmutils/xtal/coordinate.py
+++ b/lib-py/casmutils/xtal/coordinate.py
@@ -13,7 +13,7 @@ class _Coordinate:
         can be used to access the member functions
         of _xtal.Coordinate
 
-        parameters
+        Paremeters
         ----------
         coord : np.array
 
@@ -42,7 +42,7 @@ class _Coordinate:
         """Returns the fractional values of the coordinate
         relative to the given lattice
 
-        Parameters
+        Paremeters
         ----------
         lat : Lattice
 
@@ -76,7 +76,7 @@ class _Coordinate:
         """Constructs a Coordinate from
         fractional coordinates
 
-        Parameters
+        Paremeters
         ----------
         coords : np.array
         lat : Lattice
@@ -94,7 +94,7 @@ class _Coordinate:
         of Coordinates (e.g. compare Cartesian values within tolerance, or
         compare after bringing Coordinate within a unit cell).
 
-        Parameters
+        Paremeters
         ----------
         method : Functor class that performs the evaluation
         *args : Arguments needed to construct method
@@ -110,7 +110,7 @@ class _Coordinate:
         """Passes the "other" value to the current comparator
         stored in the Coordinate instance and returns the evaluation
 
-        Parameters
+        Paremeters
         ----------
         other : Coordinate
 
@@ -129,7 +129,7 @@ class _Coordinate:
         stored in the Coordinate instance and returns the
         opposite of the evaluation
 
-        Parameters
+        Paremeters
         ----------
         other : Coordinate
 
@@ -143,7 +143,7 @@ class _Coordinate:
     def __add__(self, other):
         """Adds the "other" value to the Coordinate instance
 
-        Parameters
+        Paremeters
         ----------
         other : Coordinate
 
@@ -165,11 +165,11 @@ class Coordinate(_Coordinate):
         """Constructor inheriting from the
         parent _Coordinate
 
-        parameters
+        Paremeters
         ----------
         coord : np.array
 
-        returns
+        Returns
         -------
         TODO
 
@@ -181,7 +181,7 @@ class Coordinate(_Coordinate):
         translations that bring it within the unit cell of the
         given lattice
 
-        Parameters
+        Paremeters
         ----------
         lat : Lattice
 
@@ -203,11 +203,11 @@ class MutableCoordinate(_Coordinate):
         """constructor that inherits from the
         parent _Coordinate
 
-        parameters
+        Paremeters
         ----------
         coord : np.array
 
-        returns
+        Returns
         -------
         TODO
 
@@ -219,7 +219,7 @@ class MutableCoordinate(_Coordinate):
         that bring it within the unit cell of the
         given lattice
 
-        Parameters
+        Paremeters
         ----------
         lat : Lattice
 
@@ -235,7 +235,7 @@ class MutableCoordinate(_Coordinate):
         """Adds the "other" value to the current MutableCoordinate
         instance and makes it the cuurent instance
 
-        Parameters
+        Paremeters
         ----------
         other : MutableCoordinate
 

--- a/lib-py/casmutils/xtal/coordinate.py
+++ b/lib-py/casmutils/xtal/coordinate.py
@@ -17,7 +17,7 @@ class _Coordinate:
         ----------
         coord : np.array
 
-        returns
+        Returns
         -------
         TODO
 

--- a/lib-py/casmutils/xtal/coordinate.py
+++ b/lib-py/casmutils/xtal/coordinate.py
@@ -15,7 +15,7 @@ class Equals:
         tol : double
 
         """
-        self.CoordinateEquals_f = _xtal.CoordinateEquals_f(ref_coordinate._pybind_value, tol)
+        self._CoordinateEquals_f = _xtal.CoordinateEquals_f(ref_coordinate._pybind_value, tol)
 
     def __call__(self, other):
         """Overloading () operator
@@ -29,7 +29,7 @@ class Equals:
         bool
 
         """
-        return self.CoordinateEquals_f(other._pybind_value)
+        return self._CoordinateEquals_f(other._pybind_value)
 
 class _Coordinate:
 

--- a/lib-py/casmutils/xtal/coordinate.py
+++ b/lib-py/casmutils/xtal/coordinate.py
@@ -1,7 +1,37 @@
 from . import _xtal
 from . import globaldef
 
-Equals=_xtal.CoordinateEquals_f
+class Equals:
+
+    """A wrapper class for _xtal.CoordinateEquals_f"""
+
+    def __init__(self, ref_coordinate, tol):
+        """Construct Equals from Coordinate
+        or MutableCoordinate & a given tolerance
+
+        Parameters
+        ----------
+        ref_coordinate : Coordinate or MutableCoordinate
+        tol : double
+
+        """
+        self.ref_coordinate = ref_coordinate
+        self.tol = tol
+
+    def __call__(self, other):
+        """Overloading () operator
+
+        Parameters
+        ----------
+        other : Coordinate or MutableCoordinate
+
+        Returns
+        -------
+        bool
+
+        """
+        self.CoordinateEquals_f = _xtal.CoordinateEquals_f(self.ref_coordinate._pybind_value, self.tol)
+        return self.CoordinateEquals_f(other._pybind_value)
 
 class _Coordinate:
 
@@ -97,7 +127,7 @@ class _Coordinate:
         *args : Arguments needed to construct method
 
         """
-        self._equals=method(self._pybind_value, *args)
+        self._equals=method(self, *args)
 
     def __eq__(self, other):
         """Passes the "other" value to the current comparator
@@ -113,9 +143,9 @@ class _Coordinate:
 
         """
         if hasattr(self,'_equals') is False:
-            self._equals=Equals(self._pybind_value,globaldef.tol)
+            self.set_compare_method(Equals, globaldef.tol)
 
-        return self._equals(other._pybind_value)
+        return self._equals(other)
 
     def __ne__(self, other):
         """Passes the "other" value to the current comparator

--- a/lib-py/casmutils/xtal/globaldef.py
+++ b/lib-py/casmutils/xtal/globaldef.py
@@ -18,10 +18,7 @@ def _is_pybind_value(value):
     bool
 
     """
-    if type(value).__name__ =="Site" and hasattr(value,"_cart_const"):
-        return True
-
-    elif type(value).__name__=="Coordinate" and hasattr(value,"_cart_const"):
+    if ("_xtal" in type(value).__module__) is True:
         return True
 
     else:

--- a/lib-py/casmutils/xtal/globaldef.py
+++ b/lib-py/casmutils/xtal/globaldef.py
@@ -1,0 +1,28 @@
+#!@PYTHON@
+
+""" All the global definitions are declared here """
+
+"""Tolerance"""
+tol = 1e-5
+
+def _is_pybind_value(value):
+    """Checks if the value passed
+    is of py_bind type
+
+    Parameters
+    ----------
+    value : any type
+
+    Returns
+    -------
+    bool
+
+    """
+    if type(value).__name__ =="Site" and hasattr(value,"_cart_const"):
+        return True
+
+    elif type(value).__name__=="Coordinate" and hasattr(value,"_cart_const"):
+        return True
+
+    else:
+        return False

--- a/lib-py/casmutils/xtal/globaldef.py
+++ b/lib-py/casmutils/xtal/globaldef.py
@@ -7,7 +7,7 @@ tol = 1e-5
 
 def _is_pybind_value(value):
     """Checks if the value passed
-    is of py_bind type
+    is of _py_bind type
 
     Parameters
     ----------

--- a/lib-py/casmutils/xtal/globalvar.py
+++ b/lib-py/casmutils/xtal/globalvar.py
@@ -1,6 +1,0 @@
-#!@PYTHON@
-
-""" All the global variables declared here """
-
-"""Tolerance"""
-tol = 1e-5

--- a/lib-py/casmutils/xtal/globalvar.py
+++ b/lib-py/casmutils/xtal/globalvar.py
@@ -1,0 +1,6 @@
+#!@PYTHON@
+
+""" All the global variables declared here """
+
+"""Tolerance"""
+tol = 1e-5

--- a/lib-py/casmutils/xtal/site.py
+++ b/lib-py/casmutils/xtal/site.py
@@ -1,4 +1,5 @@
 from . import _xtal
+from . import globalvar
 
 Equals = _xtal.SiteEquals_f
 
@@ -17,10 +18,6 @@ class _Site:
         coord : np.array
         label : string
 
-        Returns
-        -------
-        TODO
-
         """
         self._pybind_value = _xtal.Site(coord,label)
 
@@ -32,7 +29,7 @@ class _Site:
         np.array
 
         """
-        return self._pybind_value.cart()
+        return self._pybind_value._cart_const()
 
     def frac(self, lat):
         """Returns fractional coordinates of the Site
@@ -46,7 +43,7 @@ class _Site:
         np.array
 
         """
-        return self._pybind_value.frac(lat)
+        return self._pybind_value._frac_const(lat)
 
     def label(self):
         """Returns label of atom at the Site
@@ -56,7 +53,7 @@ class _Site:
         string
 
         """
-        return self._pybind_value.label()
+        return self._pybind_value._label_const()
 
     def set_compare_method(self, method, *args):
         """Determines what strategy to use for comparing
@@ -66,10 +63,6 @@ class _Site:
         ----------
         method : Functor class that performs the comparision
         *args : Arguments needed to construct the Functor
-
-        Returns
-        -------
-        TODO
 
         """
         self._equals = method(self._pybind_value, *args)
@@ -88,7 +81,7 @@ class _Site:
 
         """
         if hasattr(self, '_equals') is False:
-            self._equals = Equals(self._pybind_value, 1e-5)
+            self._equals = Equals(self._pybind_value, globalvar.tol)
 
         return self._equals(other._pybind_value)
 
@@ -121,10 +114,6 @@ class Site(_Site):
         coord : np.array
         label : string
 
-        Returns
-        -------
-        TODO
-
         """
         super().__init__(coord, label)
 
@@ -140,10 +129,6 @@ class MutableSite(_Site):
         ----------
         coord : np.array
         label : string
-
-        Returns
-        -------
-        TODO
 
         """
         super().__init__(coord, label)

--- a/lib-py/casmutils/xtal/site.py
+++ b/lib-py/casmutils/xtal/site.py
@@ -1,5 +1,5 @@
 from . import _xtal
-from . import globalvar
+from . import globaldef
 
 Equals = _xtal.SiteEquals_f
 
@@ -65,7 +65,11 @@ class _Site:
         *args : Arguments needed to construct the Functor
 
         """
-        self._equals = method(self._pybind_value, *args)
+        try:
+            self._equals = method(self, *args)
+
+        except TypeError:
+            self._equals = method(self._pybind_value, *args)
 
     def __eq__(self, other):
         """Passes the "other" to the cuurent compare functor
@@ -81,9 +85,13 @@ class _Site:
 
         """
         if hasattr(self, '_equals') is False:
-            self._equals = Equals(self._pybind_value, globalvar.tol)
+            self.set_compare_method(Equals, globaldef.tol)
 
-        return self._equals(other._pybind_value)
+        try:
+            return self._equals(other)
+
+        except TypeError:
+            return self._equals(other._pybind_value)
 
     def __ne__(self, other):
         """Passes the "other" to the current compare functor

--- a/lib-py/casmutils/xtal/site.py
+++ b/lib-py/casmutils/xtal/site.py
@@ -1,7 +1,37 @@
 from . import _xtal
 from . import globaldef
 
-Equals = _xtal.SiteEquals_f
+class Equals:
+
+    """A wrapper class for _xtal.SiteEquals_f"""
+
+    def __init__(self, ref_site, tol):
+        """Construct Equals from Site
+        or MutableSite and a given tolerance
+
+        Parameters
+        ----------
+        ref_site : Site or MutableSite
+        tol : double
+
+        """
+        self.ref_site = ref_site
+        self.tol = tol
+
+    def __call__(self, other):
+        """Overloading () operator
+
+        Parameters
+        ----------
+        other : Site or MutableSite
+
+        Returns
+        -------
+        bool
+
+        """
+        self.SiteEquals_f = _xtal.SiteEquals_f(self.ref_site._pybind_value, self.tol)
+        return self.SiteEquals_f(other._pybind_value)
 
 class _Site:
 
@@ -65,11 +95,7 @@ class _Site:
         *args : Arguments needed to construct the Functor
 
         """
-        try:
-            self._equals = method(self, *args)
-
-        except TypeError:
-            self._equals = method(self._pybind_value, *args)
+        self._equals = method(self, *args)
 
     def __eq__(self, other):
         """Passes the "other" to the cuurent compare functor
@@ -87,11 +113,7 @@ class _Site:
         if hasattr(self, '_equals') is False:
             self.set_compare_method(Equals, globaldef.tol)
 
-        try:
-            return self._equals(other)
-
-        except TypeError:
-            return self._equals(other._pybind_value)
+        return self._equals(other)
 
     def __ne__(self, other):
         """Passes the "other" to the current compare functor

--- a/lib-py/casmutils/xtal/site.py
+++ b/lib-py/casmutils/xtal/site.py
@@ -15,7 +15,7 @@ class Equals:
         tol : double
 
         """
-        self.SiteEquals_f = _xtal.SiteEquals_f(ref_site._pybind_value, tol)
+        self._SiteEquals_f = _xtal.SiteEquals_f(ref_site._pybind_value, tol)
 
     def __call__(self, other):
         """Overloading () operator
@@ -29,7 +29,7 @@ class Equals:
         bool
 
         """
-        return self.SiteEquals_f(other._pybind_value)
+        return self._SiteEquals_f(other._pybind_value)
 
 class _Site:
 

--- a/lib-py/casmutils/xtal/site.py
+++ b/lib-py/casmutils/xtal/site.py
@@ -15,8 +15,7 @@ class Equals:
         tol : double
 
         """
-        self.ref_site = ref_site
-        self.tol = tol
+        self.SiteEquals_f = _xtal.SiteEquals_f(ref_site._pybind_value, tol)
 
     def __call__(self, other):
         """Overloading () operator
@@ -30,7 +29,6 @@ class Equals:
         bool
 
         """
-        self.SiteEquals_f = _xtal.SiteEquals_f(self.ref_site._pybind_value, self.tol)
         return self.SiteEquals_f(other._pybind_value)
 
 class _Site:

--- a/lib-py/casmutils/xtal/site.py
+++ b/lib-py/casmutils/xtal/site.py
@@ -12,7 +12,7 @@ class _Site:
         as a container to access it's member
         functions
 
-        paremeters
+        Parameters
         ----------
         coord : np.array
         label : string
@@ -37,7 +37,7 @@ class _Site:
     def frac(self, lat):
         """Returns fractional coordinates of the Site
 
-        parameters
+        Parameters
         ----------
         lat : Lattice
 
@@ -97,7 +97,7 @@ class _Site:
         and compares it to the self and returns opposite of the
         evaluation
 
-        Paremeters
+        Parameters
         ----------
         other : _Site
 
@@ -116,7 +116,7 @@ class Site(_Site):
         """Constructor inheriting from
         parent's constructor
 
-        Paremeters
+        Parameters
         ----------
         coord : np.array
         label : string
@@ -136,7 +136,7 @@ class MutableSite(_Site):
         """Constructor inheriting from
         parent's constructor
 
-        Paremeters
+        Parameters
         ----------
         coord : np.array
         label : string

--- a/lib-py/casmutils/xtal/site.py
+++ b/lib-py/casmutils/xtal/site.py
@@ -1,0 +1,150 @@
+from . import _xtal
+
+Equals = _xtal.SiteEquals_f
+
+class _Site:
+
+    """Base class for both mutable and immutable Site classes.
+    Defines the functions that should be common to both"""
+
+    def __init__(self,coord,label):
+        """create an instance of _xtal.Site
+        as a container to access it's member
+        functions
+
+        paremeters
+        ----------
+        coord : np.array
+        label : string
+
+        Returns
+        -------
+        TODO
+
+        """
+        self._pybind_value = _xtal.Site(coord,label)
+
+    def cart(self):
+        """Returns cartesian coordinates of the Site
+
+        Returns
+        -------
+        np.array
+
+        """
+        return self._pybind_value.cart()
+
+    def frac(self, lat):
+        """Returns fractional coordinates of the Site
+
+        parameters
+        ----------
+        lat : Lattice
+
+        Returns
+        -------
+        np.array
+
+        """
+        return self._pybind_value.frac(lat)
+
+    def label(self):
+        """Returns label of atom at the Site
+
+        Returns
+        -------
+        string
+
+        """
+        return self._pybind_value.label()
+
+    def set_compare_method(self, method, *args):
+        """Determines what strategy to use for comparing
+        Sites
+
+        Parameters
+        ----------
+        method : Functor class that performs the comparision
+        *args : Arguments needed to construct the Functor
+
+        Returns
+        -------
+        TODO
+
+        """
+        self._equals = method(self._pybind_value, *args)
+
+    def __eq__(self, other):
+        """Passes the "other" to the cuurent compare functor
+        and compares it to the self and returns the evaluation
+
+        Parameters
+        ----------
+        other : _Site
+
+        Returns
+        -------
+        bool
+
+        """
+        if hasattr(self, '_equals') is False:
+            self._equals = Equals(self._pybind_value, 1e-5)
+
+        return self._equals(other._pybind_value)
+
+    def __ne__(self, other):
+        """Passes the "other" to the current compare functor
+        and compares it to the self and returns opposite of the
+        evaluation
+
+        Paremeters
+        ----------
+        other : _Site
+
+        Returns
+        -------
+        bool
+
+        """
+        return not self==other
+
+class Site(_Site):
+
+    """Immutable Site Class"""
+
+    def __init__(self, coord, label):
+        """Constructor inheriting from
+        parent's constructor
+
+        Paremeters
+        ----------
+        coord : np.array
+        label : string
+
+        Returns
+        -------
+        TODO
+
+        """
+        super().__init__(coord, label)
+
+class MutableSite(_Site):
+
+    """Mutable Site Class"""
+
+    def __init__(self, coord, label):
+        """Constructor inheriting from
+        parent's constructor
+
+        Paremeters
+        ----------
+        coord : np.array
+        label : string
+
+        Returns
+        -------
+        TODO
+
+        """
+        super().__init__(coord, label)
+

--- a/lib-py/casmutils/xtal/xtal.py
+++ b/lib-py/casmutils/xtal/xtal.py
@@ -6,6 +6,7 @@ from .coordinate import Coordinate
 from .coordinate import MutableCoordinate
 from .lattice import *
 from .site import *
+from .globalvar import *
 # from .single_block_wadsley_roth import *
 
 def extra_function(self):

--- a/lib-py/casmutils/xtal/xtal.py
+++ b/lib-py/casmutils/xtal/xtal.py
@@ -5,6 +5,7 @@ from . import coordinate
 from .coordinate import Coordinate
 from .coordinate import MutableCoordinate
 from .lattice import *
+from .site import *
 # from .single_block_wadsley_roth import *
 
 def extra_function(self):

--- a/tests/py/coordinate.py.in
+++ b/tests/py/coordinate.py.in
@@ -28,9 +28,7 @@ class CoordinateTest(unittest.TestCase):
         self.coord0.set_compare_method(cu.xtal.coordinate.Equals,1e-5)
         self.coord1.set_compare_method(cu.xtal.coordinate.Equals,1e-5)
         self.coord0f.set_compare_method(cu.xtal.coordinate.Equals,1e-5)
-        self.coord1f.set_compare_method(cu.xtal.coordinate.Equals,1e-5)
         self.coord0m.set_compare_method(cu.xtal.coordinate.Equals,1e-5)
-        self.coord1m.set_compare_method(cu.xtal.coordinate.Equals,1e-5)
 
     def test_construct(self):
         self.assertFalse(self.coord0==self.coord1)

--- a/tests/py/site.py.in
+++ b/tests/py/site.py.in
@@ -4,6 +4,41 @@ import unittest
 import casmutils as cu
 import numpy as np
 
+class SiteEquals_f:
+    """A custom Site compare method
+        which compares only the
+        coordinates and returns true
+        if they are the same."""
+
+    def __init__(self, ref_site, tol):
+        """Constructs the functor with
+        Site
+
+        Parameters
+        ----------
+        site : cu.xtal._xtal.Site
+
+        """
+        self.ref_site = ref_site
+        self.tol = tol
+
+    def __call__(self, other):
+        """Overloading the () operator
+
+        Parameters
+        ----------
+        other : cu.xtal._xtal.Site
+
+        Returns
+        -------
+        bool
+
+        """
+        if np.allclose(self.ref_site._cart_const(),other._cart_const(),self.tol,self.tol) is True:
+            return True
+        else:
+            return False
+
 class SiteTest(unittest.TestCase):
     def setUp(self):
         """Setting up numpy arrays and labels for atoms"""
@@ -12,6 +47,7 @@ class SiteTest(unittest.TestCase):
         self.raw_coord1 = np.array([0.2,0.4,0.6])
         self.atom0 = "O"
         self.atom1 = "P"
+        self.tol = cu.xtal.globalvar.tol
 
         """Computing fractional coordinates manually"""
         self.frac_coords0 = np.dot(np.linalg.inv(self.lattice_matrix),self.raw_coord0)
@@ -40,16 +76,21 @@ class SiteTest(unittest.TestCase):
         self.assertTrue(np.array_equal(self.site0m.cart(),self.raw_coord0))
 
     def test_frac(self):
-        self.assertTrue(np.array_equal(self.site0.frac(self.lat),self.frac_coords0))
-        self.assertTrue(np.array_equal(self.site0m.frac(self.lat),self.frac_coords0))
+        self.assertTrue(np.allclose(self.site0.frac(self.lat),self.frac_coords0,self.tol,self.tol))
+        self.assertTrue(np.allclose(self.site0m.frac(self.lat),self.frac_coords0,self.tol,self.tol))
 
     def test_label(self):
-        self.assertTrue(self.site0.label() == self.atom0)
-        self.assertTrue(self.site0m.label() == self.atom0)
-        self.assertTrue(self.site1.label() == self.atom1)
-        self.assertTrue(self.site1m.label() == self.atom1)
-        self.assertFalse(self.site1.label() == self.atom0)
-        self.assertFalse(self.site1m.label() == self.atom0)
+        self.assertTrue(self.site0.label()==self.atom0)
+        self.assertTrue(self.site0m.label()==self.atom0)
+        self.assertTrue(self.site1.label()==self.atom1)
+        self.assertTrue(self.site1m.label()==self.atom1)
+        self.assertFalse(self.site1.label()==self.atom0)
+        self.assertFalse(self.site1m.label()==self.atom0)
+
+    def test_set_compare_method(self):
+        self.assertFalse(self.site2m==self.site0m)
+        self.site2m.set_compare_method(SiteEquals_f, self.tol)
+        self.assertTrue(self.site2m==self.site0m)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/py/site.py.in
+++ b/tests/py/site.py.in
@@ -34,7 +34,7 @@ class SiteEquals_f:
         bool
 
         """
-        if np.allclose(self.ref_site._cart_const(),other._cart_const(),self.tol,self.tol) is True:
+        if np.allclose(self.ref_site.cart(),other.cart(),self.tol,self.tol) is True:
             return True
         else:
             return False
@@ -47,7 +47,7 @@ class SiteTest(unittest.TestCase):
         self.raw_coord1 = np.array([0.2,0.4,0.6])
         self.atom0 = "O"
         self.atom1 = "P"
-        self.tol = cu.xtal.globalvar.tol
+        self.tol = cu.xtal.globaldef.tol
 
         """Computing fractional coordinates manually"""
         self.frac_coords0 = np.dot(np.linalg.inv(self.lattice_matrix),self.raw_coord0)

--- a/tests/py/site.py.in
+++ b/tests/py/site.py.in
@@ -16,7 +16,7 @@ class SiteEquals_f:
 
         Parameters
         ----------
-        site : cu.xtal._xtal.Site
+        ref_site : cu.xtal._xtal.Site
 
         """
         self.ref_site = ref_site

--- a/tests/py/site.py.in
+++ b/tests/py/site.py.in
@@ -4,7 +4,7 @@ import unittest
 import casmutils as cu
 import numpy as np
 
-class SiteEquals_f:
+class SiteCoordinateEquals:
     """A custom Site compare method
         which compares only the
         coordinates and returns true
@@ -16,7 +16,8 @@ class SiteEquals_f:
 
         Parameters
         ----------
-        ref_site : Site
+        ref_site : Site or MutableSite
+        tol : double
 
         """
         self.ref_site = ref_site
@@ -89,7 +90,7 @@ class SiteTest(unittest.TestCase):
 
     def test_set_compare_method(self):
         self.assertFalse(self.site2m==self.site0m)
-        self.site2m.set_compare_method(SiteEquals_f, self.tol)
+        self.site2m.set_compare_method(SiteCoordinateEquals, self.tol)
         self.assertTrue(self.site2m==self.site0m)
 
 if __name__ == '__main__':

--- a/tests/py/site.py.in
+++ b/tests/py/site.py.in
@@ -20,8 +20,8 @@ class SiteCoordinateEquals:
         tol : double
 
         """
-        self.ref_site = ref_site
-        self.tol = tol
+        self._ref_site = ref_site
+        self._tol = tol
 
     def __call__(self, other):
         """Overloading the () operator
@@ -35,7 +35,7 @@ class SiteCoordinateEquals:
         bool
 
         """
-        if np.allclose(self.ref_site.cart(),other.cart(),self.tol,self.tol) is True:
+        if np.allclose(self._ref_site.cart(),other.cart(),self._tol,self._tol) is True:
             return True
         else:
             return False

--- a/tests/py/site.py.in
+++ b/tests/py/site.py.in
@@ -1,0 +1,43 @@
+#!@PYTHON@
+
+import unittest
+import casmutils as cu
+import numpy as np
+
+class SiteTest(unittest.TestCase):
+    def setUp(self):
+        """Setting up numpy arrays and labels for atoms"""
+        self.lattice_matrix = np.array([[0,0.5,0.5],[0.5,0,0.5],[0.5,0.5,0]])
+        self.raw_coord0 = np.array([0.1,0.2,0.3])
+        self.raw_coord1 = np.array([0.2,0.4,0.6])
+        self.atom0 = "O"
+        self.atom1 = "P"
+
+        """Computing fractional coordinates manually"""
+        self.frac_coords0 = np.dot(np.linalg.inv(self.lattice_matrix),self.raw_coord0)
+
+        """Constructing required classes"""
+        self.lat = cu.xtal.Lattice(*self.lattice_matrix)
+        self.site0 = cu.xtal.Site(self.raw_coord0,self.atom0)
+        self.site1 = cu.xtal.Site(self.raw_coord1,self.atom1)
+        self.site2 = cu.xtal.Site(self.raw_coord0,self.atom1)
+
+    def test_construct(self):
+        self.assertFalse(self.site0==self.site1)
+        self.assertTrue(self.site0!=self.site1)
+        self.assertFalse(self.site2==self.site0)
+        self.assertFalse(self.site2==self.site1)
+
+    def test_cart(self):
+        self.assertTrue(np.array_equal(self.site0.cart(),self.raw_coord0))
+
+    def test_frac(self):
+        self.assertTrue(np.array_equal(self.site0.frac(self.lat),self.frac_coords0))
+
+    def test_label(self):
+        self.assertTrue(self.site0.label() == self.atom0)
+        self.assertTrue(self.site1.label() == self.atom1)
+        self.assertFalse(self.site1.label() == self.atom0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/py/site.py.in
+++ b/tests/py/site.py.in
@@ -16,7 +16,7 @@ class SiteEquals_f:
 
         Parameters
         ----------
-        ref_site : cu.xtal._xtal.Site
+        ref_site : Site
 
         """
         self.ref_site = ref_site
@@ -27,7 +27,7 @@ class SiteEquals_f:
 
         Parameters
         ----------
-        other : cu.xtal._xtal.Site
+        other : Site
 
         Returns
         -------

--- a/tests/py/site.py.in
+++ b/tests/py/site.py.in
@@ -19,25 +19,37 @@ class SiteTest(unittest.TestCase):
         """Constructing required classes"""
         self.lat = cu.xtal.Lattice(*self.lattice_matrix)
         self.site0 = cu.xtal.Site(self.raw_coord0,self.atom0)
+        self.site0m = cu.xtal.MutableSite(self.raw_coord0,self.atom0)
         self.site1 = cu.xtal.Site(self.raw_coord1,self.atom1)
+        self.site1m = cu.xtal.MutableSite(self.raw_coord1,self.atom1)
         self.site2 = cu.xtal.Site(self.raw_coord0,self.atom1)
+        self.site2m = cu.xtal.MutableSite(self.raw_coord0,self.atom1)
 
     def test_construct(self):
         self.assertFalse(self.site0==self.site1)
+        self.assertFalse(self.site0m==self.site1m)
         self.assertTrue(self.site0!=self.site1)
+        self.assertTrue(self.site0m!=self.site1m)
         self.assertFalse(self.site2==self.site0)
+        self.assertFalse(self.site2m==self.site0)
         self.assertFalse(self.site2==self.site1)
+        self.assertFalse(self.site2m==self.site1m)
 
     def test_cart(self):
         self.assertTrue(np.array_equal(self.site0.cart(),self.raw_coord0))
+        self.assertTrue(np.array_equal(self.site0m.cart(),self.raw_coord0))
 
     def test_frac(self):
         self.assertTrue(np.array_equal(self.site0.frac(self.lat),self.frac_coords0))
+        self.assertTrue(np.array_equal(self.site0m.frac(self.lat),self.frac_coords0))
 
     def test_label(self):
         self.assertTrue(self.site0.label() == self.atom0)
+        self.assertTrue(self.site0m.label() == self.atom0)
         self.assertTrue(self.site1.label() == self.atom1)
+        self.assertTrue(self.site1m.label() == self.atom1)
         self.assertFalse(self.site1.label() == self.atom0)
+        self.assertFalse(self.site1m.label() == self.atom0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Wrote missing pybinds for xtal::Site (SiteCompare_f & xtal::Site::label())
- Set up _Site class which has a _xtal.Site instance through all the member functions common to Site and MutableSite can be accessed
-  Set up MutableSite and Site python classes to inherit from _Site. Currently there are no unique functions (i.e., both of them are the same)
- Set up python tests for Site and MutableSite