### PR TITLE
Python bindings for point group and factor group

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,8 @@ AC_CONFIG_FILES([tests/py/lattice.py],[chmod +x tests/py/lattice.py])
 AC_CONFIG_FILES([tests/py/structure.py],[chmod +x tests/py/structure.py])
 AC_CONFIG_FILES([tests/py/casmutils/mapping/mapping.py],[chmod +x tests/py/casmutils/mapping/mapping.py])
 AC_CONFIG_FILES([tests/py/casmutils/mapping/structure.py],[chmod +x tests/py/casmutils/mapping/structure.py])
+AC_CONFIG_FILES([tests/py/casmutils/sym/cart.py],[chmod +x tests/py/casmutils/sym/cart.py])
+AC_CONFIG_FILES([tests/py/casmutils/xtal/symmetry.py],[chmod +x tests/py/casmutils/xtal/symmetry.py])
 
 AC_CONFIG_FILES([tests/integration/phony_module_installation.sh])
 AC_CONFIG_FILES([tests/integration/cu-import.py],[chmod +x tests/integration/cu-import.py])

--- a/include/casmutils/mapping/structure_mapping.hpp
+++ b/include/casmutils/mapping/structure_mapping.hpp
@@ -65,7 +65,7 @@ struct MappingReport
 /// invalid mappings, whether the structure being mapped is ideal, the
 /// potential to impose a lattice to map the test structure onto (must be a superlattice
 /// of the reference)
-//TODO: Explain each parameter in detail
+// TODO: Explain each parameter in detail
 struct MappingInput
 {
 public:
@@ -129,7 +129,7 @@ private:
 /// different test structures to the same reference.
 /// Default values for the point group is the factor group of the reference structure,
 /// and the allowed species are whatever is residing at the reference structure.
-//TODO: Explain each constructor argument in detail
+// TODO: Explain each constructor argument in detail
 class StructureMapper_f
 {
 public:

--- a/include/casmutils/xtal/coordinate.hpp
+++ b/include/casmutils/xtal/coordinate.hpp
@@ -38,6 +38,8 @@ public:
     /// Translate *this by the given coordinate
     Coordinate& operator+=(const Coordinate& coord_to_add);
 
+    // TODO: These are annoying as member functions. Make them standalone.
+    // and let them accept Eigen::Vector3d as well. Same with the wigner-seitz
     /// Bring *this within the given lattice
     void bring_within(const Lattice& lat);
 
@@ -58,6 +60,7 @@ private:
     CASM::xtal::Coordinate casm_coord;
 };
 
+// TODO: make this binary, not unary (same with all other comparators)
 struct CoordinateEquals_f
 {
     /// for casmutils::xtal::Coordinate

--- a/include/casmutils/xtal/symmetry.hpp
+++ b/include/casmutils/xtal/symmetry.hpp
@@ -20,9 +20,10 @@ std::vector<sym::CartOp> make_point_group(const Lattice& lat, double tol);
 /// crystal structure onto itself.
 std::vector<sym::CartOp> make_factor_group(const Structure& struc, double tol);
 
+// TODO: Commented out until someone shows that this actually works
 /// Modify the given Lattice such that it perfectly obeys the provided
 /// symmetry group. Useful for reducing noise in lattice vectors.
-Lattice symmetrize(const Lattice& noisy_lattice, const std::vector<sym::CartOp>& enforced_point_group);
+/* Lattice symmetrize(const Lattice& noisy_lattice, const std::vector<sym::CartOp>& enforced_point_group); */
 
 // TODO: Does this even make sense?
 /// Modify the given Structure such that it perfectly obeys the provided

--- a/lib-py/casmutils/sym/_sym/sym-py.cxx
+++ b/lib-py/casmutils/sym/_sym/sym-py.cxx
@@ -24,10 +24,9 @@ PYBIND11_MODULE(_sym, m)
                , such as crystal structures or clusters.";
 
     {
-        // TODO: Have a copy of this class with only def_read and then make this one MutableCartOp?
-        // or should we just stick to that distinction for classes that have non-const functions?
         class_<sym::CartOp>(m, "CartOp")
             .def(init<const Eigen::Matrix3d&, const Eigen::Vector3d&, bool>())
+            .def(init<const sym::CartOp&>())
             .def_static("identity", &sym::CartOp::identity)
             .def_static("time_reversal", &sym::CartOp::time_reversal)
             .def_static("translation_operation", &sym::CartOp::translation_operation)

--- a/lib-py/casmutils/sym/cart.py
+++ b/lib-py/casmutils/sym/cart.py
@@ -5,11 +5,8 @@ from . import _sym
 
 class CartOp(_sym.CartOp):
     """Basic symmetry operation that deals with Cartesian representations.
-    Conains a matrix, translation, and time reversal boolean."""
-
-    # def __init__(self):
-    #     """Initialize with the matrix, translation, and time reversal bool """
-    #     _sym.CartOp.__init__(self)
+    Conains a matrix, translation, and time reversal boolean.
+    Construct with a 3x3 matrix, 3x1 vector, boolean."""
 
     def __str__(self):
         """Concatenates __str__ of each member (matrix, vector, bool)
@@ -42,8 +39,7 @@ class CartOp(_sym.CartOp):
         CartOp
 
         """
-        S=super().identity()
-        return CartOp(S.matrix,S.translation,S.is_time_reversal_active)
+        return cls(super().identity())
 
     @classmethod
     def time_reversal(cls):
@@ -53,8 +49,7 @@ class CartOp(_sym.CartOp):
         CartOp
 
         """
-        S=super().time_reversal()
-        return CartOp(S.matrix,S.translation,S.is_time_reversal_active)
+        return cls(super().time_reversal())
 
     @classmethod
     def translation_operation(cls, translation):
@@ -69,8 +64,7 @@ class CartOp(_sym.CartOp):
         CartOp
 
         """
-        S=super().translation_operation(translation)
-        return CartOp(S.matrix,S.translation,S.is_time_reversal_active)
+        return cls(super().translation_operation(translation))
 
     @classmethod
     def point_operation(cls, matrix):
@@ -85,5 +79,4 @@ class CartOp(_sym.CartOp):
         CartOp
 
         """
-        S=super().point_operation(matrix)
-        return CartOp(S.matrix,S.translation,S.is_time_reversal_active)
+        return cls(super().point_operation(matrix))

--- a/lib-py/casmutils/xtal/Makemodule.am
+++ b/lib-py/casmutils/xtal/Makemodule.am
@@ -8,6 +8,7 @@ xtalpy_PYTHON=\
 			  lib-py/casmutils/xtal/site.py\
 			  lib-py/casmutils/xtal/structure.py\
 			  lib-py/casmutils/xtal/globaldef.py\
+			  lib-py/casmutils/xtal/symmetry.py\
 			  lib-py/casmutils/xtal/xtal.py
 
 xtalpy_LTLIBRARIES=\

--- a/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
+++ b/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
@@ -9,6 +9,7 @@
 #include <casmutils/xtal/rocksalttoggler.hpp>
 #include <casmutils/xtal/structure.hpp>
 #include <casmutils/xtal/structure_tools.hpp>
+#include <casmutils/xtal/symmetry.hpp>
 #include <fstream>
 #include <string>
 
@@ -134,6 +135,9 @@ PYBIND11_MODULE(_xtal, m)
     m.def("apply_deformation", (xtal::Structure(*)(const xtal::Structure&, const Eigen::Matrix3d&))casmutils::xtal::apply_deformation);
     //m.def("structure_score", (std::vector<std::pair<double, double>>(*)(const rewrap::Structure&, const std::vector<rewrap::Structure>&))casmutils::xtal::structure_score);
     m.def("make_superstructures_of_volume", (std::vector<xtal::Structure>(*)(const xtal::Structure&, const int))casmutils::xtal::make_superstructures_of_volume);
+
+    m.def("make_point_group", casmutils::xtal::make_point_group);
+    m.def("make_factor_group", casmutils::xtal::make_factor_group);
     // clang-format on
 }
 } // namespace wrappy

--- a/lib-py/casmutils/xtal/symmetry.py
+++ b/lib-py/casmutils/xtal/symmetry.py
@@ -1,0 +1,34 @@
+from . import _xtal
+from ..sym.cart import CartOp
+
+def make_point_group(lattice, tol):
+    """Calculate all symmetry operations that map the given
+    lattice onto itself
+
+    Parameters
+    ----------
+    lattice : Lattice
+    tol : float
+
+    Returns
+    -------
+    list(cu.sym.CartOp)
+
+    """
+    return [CartOp(op) for op in _xtal.make_point_group(lattice,tol)]
+
+def make_factor_group(structure, tol):
+    """Calculate all symmetry operations that map the given
+    structure onto itself
+
+    Parameters
+    ----------
+    lattice : Structure
+    tol : float
+
+    Returns
+    -------
+    list(cu.sym.CartOp)
+
+    """
+    return [CartOp(op) for op in _xtal.make_factor_group(structure._pybind_value,tol)]

--- a/lib-py/casmutils/xtal/xtal.py
+++ b/lib-py/casmutils/xtal/xtal.py
@@ -7,6 +7,7 @@ from .coordinate import MutableCoordinate
 from .lattice import *
 from .site import *
 from .structure import *
+from .symmetry import *
 from .globaldef import *
 
 # from .single_block_wadsley_roth import *

--- a/tests/py/casmutils/Makemodule.am
+++ b/tests/py/casmutils/Makemodule.am
@@ -1,1 +1,3 @@
 include tests/py/casmutils/mapping/Makemodule.am
+include tests/py/casmutils/sym/Makemodule.am
+include tests/py/casmutils/xtal/Makemodule.am

--- a/tests/py/casmutils/sym/Makemodule.am
+++ b/tests/py/casmutils/sym/Makemodule.am
@@ -1,0 +1,2 @@
+TESTS += \
+		 tests/py/casmutils/sym/cart.py

--- a/tests/py/casmutils/sym/cart.py.in
+++ b/tests/py/casmutils/sym/cart.py.in
@@ -1,0 +1,40 @@
+#!@PYTHON@
+
+import unittest
+import numpy as np
+import casmutils as cu
+from casmutils.sym import CartOp
+
+class CartesianSymmetryTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_identity(self):
+        I=CartOp.identity()
+        self.assertTrue(np.all(I.matrix==np.eye(3,3)))
+        self.assertTrue(np.all(I.translation==np.zeros(3)))
+        self.assertFalse(I.is_time_reversal_active)
+
+    def test_time_reversal(self):
+        T=CartOp.time_reversal()
+        self.assertTrue(np.all(T.matrix==np.eye(3,3)))
+        self.assertTrue(np.all(T.translation==np.zeros(3)))
+        self.assertTrue(T.is_time_reversal_active)
+
+    def test_translation_operation(self):
+        t=np.array([0.1,0.2,-0.5])
+        T=CartOp.translation_operation(t)
+        self.assertTrue(np.all(T.matrix==np.eye(3,3)))
+        self.assertTrue(np.all(T.translation==t))
+        self.assertFalse(T.is_time_reversal_active)
+
+    def test_point_operation(self):
+        m=np.array([[0.3,0.6,-0.1],[1.5,-0.0,4.4],[2.1,-3.1,-0.1]])
+        M=CartOp.point_operation(m)
+        self.assertTrue(np.all(M.matrix==m))
+        self.assertTrue(np.all(M.translation==np.zeros(3)))
+        self.assertFalse(M.is_time_reversal_active)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/py/casmutils/xtal/Makemodule.am
+++ b/tests/py/casmutils/xtal/Makemodule.am
@@ -1,0 +1,2 @@
+TESTS += \
+		 tests/py/casmutils/xtal/symmetry.py

--- a/tests/py/casmutils/xtal/symmetry.py.in
+++ b/tests/py/casmutils/xtal/symmetry.py.in
@@ -1,0 +1,27 @@
+#!@PYTHON@
+
+import unittest
+import numpy as np
+import casmutils as cu
+import os
+
+input_file_dir = "@abs_top_srcdir@/tests/input_files"
+
+class SymmetryGroupsTest(unittest.TestCase):
+
+    def setUp(self):
+        prim_fcc_ni_path=os.path.join(input_file_dir,"primitive_fcc_Ni.vasp")
+        self.prim_fcc_ni=cu.xtal.Structure.from_poscar(prim_fcc_ni_path)
+        self.tol=1e-10;
+
+    def test_make_point_group(self):
+        pg=cu.xtal.symmetry.make_point_group(self.prim_fcc_ni.lattice(),self.tol)
+        self.assertEqual(len(pg),48);
+
+    def test_make_factor_group(self):
+        fg=cu.xtal.symmetry.make_factor_group(self.prim_fcc_ni,self.tol)
+        self.assertEqual(len(fg),48);
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/casmutils/xtal/Makemodule.am
+++ b/tests/unit/casmutils/xtal/Makemodule.am
@@ -36,3 +36,10 @@ check_xtal_structure_tools_LDADD=\
 					libgtest.la\
 					libcasmutils.la
 
+TESTS+=check_xtal_symmetry
+check_PROGRAMS += check_xtal_symmetry
+check_xtal_symmetry_SOURCES = tests/unit/casmutils/xtal/symmetry.cpp
+check_xtal_symmetry_LDADD=\
+					libgtest.la\
+					libcasmutils.la
+

--- a/tests/unit/casmutils/xtal/symmetry.cpp
+++ b/tests/unit/casmutils/xtal/symmetry.cpp
@@ -1,0 +1,43 @@
+#include "../../../autotools.hh"
+#include "casmutils/sym/cartesian.hpp"
+#include <casmutils/xtal/structure.hpp>
+#include <casmutils/xtal/symmetry.hpp>
+#include <gtest/gtest.h>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace cu = casmutils;
+
+class CrystalGroupTest : public testing::Test
+{
+protected:
+    using Structure = cu::xtal::Structure;
+
+    void SetUp() override
+    {
+        cu::fs::path primitive_fcc_path(cu::autotools::input_filesdir / "primitive_fcc_Ni.vasp");
+        primitive_fcc_Ni_ptr = std::make_unique<Structure>(Structure::from_poscar(primitive_fcc_path));
+    }
+
+    std::unique_ptr<Structure> primitive_fcc_Ni_ptr;
+    double tol = 1e-10;
+};
+
+TEST_F(CrystalGroupTest, PointGroupSize)
+{
+    std::vector<cu::sym::CartOp> point_group = cu::xtal::make_point_group(primitive_fcc_Ni_ptr->lattice(), tol);
+    EXPECT_EQ(point_group.size(), 48);
+}
+
+TEST_F(CrystalGroupTest, FactorGroupSize)
+{
+    std::vector<cu::sym::CartOp> factor_group = cu::xtal::make_factor_group(*primitive_fcc_Ni_ptr, tol);
+    EXPECT_EQ(factor_group.size(), 48);
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Added functions and python bindings for:
 * `make_point_group`
 * `make_factor_group`

The tests are pretty light, since they're just directly forwarding casm implementations that have heavier testing going on.