### PR TITLE
Doc update for MappingInput class

### DIFF
--- a/lib-py/casmutils/mapping/structure.py
+++ b/lib-py/casmutils/mapping/structure.py
@@ -110,8 +110,8 @@ class MappingInput(_mapping.MappingInput):
         max_volume_change : float, optional
         options : str, optional
         tol : float, optional
-        min_va_fraction : float, optional
-        max_va_fraction : float, optional
+        min_vacancy_fraction : float, optional
+        max_vacancy_fraction : float, optional
         k_best_maps : int, optional
         max_cost : float, optional
         min_cost : float, optional


### PR DESCRIPTION
Just a small documentation update. 
The MappingInput class accepts min_vacancy_fraction , max_vacancy_fraction as parameters.
Listing min_va_fraction, max_va_fraction in the documentation for parameters might be a bit misleading.  Hence the small change. :)