### PR TITLE
added python tests and bindings for lattice symmetrize

### DIFF
--- a/include/casmutils/xtal/symmetry.hpp
+++ b/include/casmutils/xtal/symmetry.hpp
@@ -20,18 +20,16 @@ std::vector<sym::CartOp> make_point_group(const Lattice& lat, double tol);
 /// crystal structure onto itself.
 std::vector<sym::CartOp> make_factor_group(const Structure& struc, double tol);
 
-// TODO: Commented out until someone shows that this actually works
 /// Modify the given Lattice such that it perfectly obeys the provided
 /// symmetry group. Useful for reducing noise in lattice vectors.
 Lattice symmetrize(const Lattice& noisy_lattice, const std::vector<sym::CartOp>& enforced_point_group);
 
-// TODO: Does this even make sense?
 /// Modify the given Structure such that it perfectly obeys the provided
 /// symmetry group. Useful for reducing noise in lattice vectors and basis.
 /// First, the group will by applied to the lattice, to even out the vectors.
 /// The same operations will then be applied to the basis and the resulting values
 /// will be averaged out.
-/* Lattice symmetrize(const Lattice& noisy_lattice, const std::vector<sym::CartOp>& enforced_point_group); */
+Structure symmetrize(const Structure& noisy_structure, const std::vector<sym::CartOp>& enforced_factor_group);
 
 } // namespace xtal
 } // namespace casmutils

--- a/include/casmutils/xtal/symmetry.hpp
+++ b/include/casmutils/xtal/symmetry.hpp
@@ -23,7 +23,7 @@ std::vector<sym::CartOp> make_factor_group(const Structure& struc, double tol);
 // TODO: Commented out until someone shows that this actually works
 /// Modify the given Lattice such that it perfectly obeys the provided
 /// symmetry group. Useful for reducing noise in lattice vectors.
-Lattice symmetrize(const Lattice& noisy_lattice, const std::vector<sym::CartOp>& enforced_point_group); 
+Lattice symmetrize(const Lattice& noisy_lattice, const std::vector<sym::CartOp>& enforced_point_group);
 
 // TODO: Does this even make sense?
 /// Modify the given Structure such that it perfectly obeys the provided

--- a/include/casmutils/xtal/symmetry.hpp
+++ b/include/casmutils/xtal/symmetry.hpp
@@ -23,7 +23,7 @@ std::vector<sym::CartOp> make_factor_group(const Structure& struc, double tol);
 // TODO: Commented out until someone shows that this actually works
 /// Modify the given Lattice such that it perfectly obeys the provided
 /// symmetry group. Useful for reducing noise in lattice vectors.
-/* Lattice symmetrize(const Lattice& noisy_lattice, const std::vector<sym::CartOp>& enforced_point_group); */
+Lattice symmetrize(const Lattice& noisy_lattice, const std::vector<sym::CartOp>& enforced_point_group); 
 
 // TODO: Does this even make sense?
 /// Modify the given Structure such that it perfectly obeys the provided

--- a/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
+++ b/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
@@ -137,7 +137,7 @@ PYBIND11_MODULE(_xtal, m)
 
     m.def("make_point_group", casmutils::xtal::make_point_group);
     m.def("make_factor_group", casmutils::xtal::make_factor_group);
-	m.def("symmetrize",(xtal::Lattice(*)(const xtal::Lattice&, const std::vector<sym::CartOp>&))casmutils::xtal::symmetrize); 
+	m.def("symmetrize",(xtal::Lattice(*)(const xtal::Lattice&, const std::vector<sym::CartOp>&))casmutils::xtal::symmetrize);
     // clang-format on
 }
 } // namespace wrappy

--- a/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
+++ b/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
@@ -133,11 +133,11 @@ PYBIND11_MODULE(_xtal, m)
     m.def("make_niggli", (xtal::Structure(*)(const xtal::Structure&))casmutils::xtal::make_niggli);
     m.def("apply_strain", (xtal::Structure(*)(const xtal::Structure&, const Eigen::VectorXd&, const std::string&))casmutils::xtal::apply_strain);
     m.def("apply_deformation", (xtal::Structure(*)(const xtal::Structure&, const Eigen::Matrix3d&))casmutils::xtal::apply_deformation);
-    //m.def("structure_score", (std::vector<std::pair<double, double>>(*)(const rewrap::Structure&, const std::vector<rewrap::Structure>&))casmutils::xtal::structure_score);
     m.def("make_superstructures_of_volume", (std::vector<xtal::Structure>(*)(const xtal::Structure&, const int))casmutils::xtal::make_superstructures_of_volume);
 
     m.def("make_point_group", casmutils::xtal::make_point_group);
     m.def("make_factor_group", casmutils::xtal::make_factor_group);
+	m.def("symmetrize",(xtal::Lattice(*)(const xtal::Lattice&, const std::vector<sym::CartOp>&))casmutils::xtal::symmetrize); 
     // clang-format on
 }
 } // namespace wrappy

--- a/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
+++ b/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
@@ -137,7 +137,8 @@ PYBIND11_MODULE(_xtal, m)
 
     m.def("make_point_group", casmutils::xtal::make_point_group);
     m.def("make_factor_group", casmutils::xtal::make_factor_group);
-	m.def("symmetrize",(xtal::Lattice(*)(const xtal::Lattice&, const std::vector<sym::CartOp>&))casmutils::xtal::symmetrize);
+	m.def("_symmetrize_lattice",(xtal::Lattice(*)(const xtal::Lattice&, const std::vector<sym::CartOp>&))casmutils::xtal::symmetrize);
+	m.def("_symmetrize_structure",(xtal::Structure(*)(const xtal::Structure&, const std::vector<sym::CartOp>&))casmutils::xtal::symmetrize);
     // clang-format on
 }
 } // namespace wrappy

--- a/lib-py/casmutils/xtal/symmetry.py
+++ b/lib-py/casmutils/xtal/symmetry.py
@@ -32,3 +32,14 @@ def make_factor_group(structure, tol):
 
     """
     return [CartOp(op) for op in _xtal.make_factor_group(structure._pybind_value,tol)]
+
+def symmetrize(lattice, point_group):
+    """Gives a symmetrized version of the input lattice such 
+    that it obeys the given point group
+
+    :lattice: Lattice
+    :point_group: list(cu.sym.CartOp)
+    :returns: Lattice
+
+    """
+    return _xtal.symmetrize(lattice, point_group)

--- a/lib-py/casmutils/xtal/symmetry.py
+++ b/lib-py/casmutils/xtal/symmetry.py
@@ -49,5 +49,5 @@ def symmetrize(lattice_or_structure, enforced_group):
     elif isinstance(lattice_or_structure,Structure):
         return Structure._from_pybind(_xtal._symmetrize_structure(lattice_or_structure._pybind_value,enforced_group))
     else:
-        return ValueError
+        return ValueError("symmetrize only works on Structure or Lattice types")
 

--- a/lib-py/casmutils/xtal/symmetry.py
+++ b/lib-py/casmutils/xtal/symmetry.py
@@ -1,5 +1,7 @@
 from . import _xtal
 from ..sym.cart import CartOp
+from .lattice import *
+from .structure import *
 
 def make_point_group(lattice, tol):
     """Calculate all symmetry operations that map the given
@@ -23,7 +25,7 @@ def make_factor_group(structure, tol):
 
     Parameters
     ----------
-    lattice : Structure
+    structure : Structure
     tol : float
 
     Returns
@@ -33,13 +35,19 @@ def make_factor_group(structure, tol):
     """
     return [CartOp(op) for op in _xtal.make_factor_group(structure._pybind_value,tol)]
 
-def symmetrize(lattice, point_group):
-    """Gives a symmetrized version of the input lattice such 
-    that it obeys the given point group
+def symmetrize(lattice_or_structure, enforced_group):
+    """Gives a symmetrized version of the input lattice/structure such 
+    that it obeys the given enforced symmetry group
 
-    :lattice: Lattice
-    :point_group: list(cu.sym.CartOp)
-    :returns: Lattice
+    :lattice_or_structure: Lattice or Structure
+    :enforced_group: list(cu.sym.CartOp)
+    :returns: Lattice or Structure
 
     """
-    return _xtal.symmetrize(lattice, point_group)
+    if isinstance(lattice_or_structure,Lattice):
+        return _xtal._symmetrize_lattice(lattice_or_structure,enforced_group)
+    elif isinstance(lattice_or_structure,Structure):
+        return Structure._from_pybind(_xtal._symmetrize_structure(lattice_or_structure._pybind_value,enforced_group))
+    else:
+        return ValueError
+

--- a/lib-py/casmutils/xtal/symmetry.py
+++ b/lib-py/casmutils/xtal/symmetry.py
@@ -49,5 +49,5 @@ def symmetrize(lattice_or_structure, enforced_group):
     elif isinstance(lattice_or_structure,Structure):
         return Structure._from_pybind(_xtal._symmetrize_structure(lattice_or_structure._pybind_value,enforced_group))
     else:
-        return ValueError("symmetrize only works on Structure or Lattice types")
+        raise ValueError("symmetrize only works on Structure or Lattice types")
 

--- a/lib/casmutils/xtal/symmetry.cxx
+++ b/lib/casmutils/xtal/symmetry.cxx
@@ -23,12 +23,14 @@ Lattice symmetrize(const Lattice& noisy_lattice, const std::vector<sym::CartOp>&
     return CASM::xtal::symmetrize(noisy_lattice.__get(), enforced_point_group);
 }
 
-Structure symmetrize(const Structure& noisy_structure, const std::vector<sym::CartOp>& enforced_factor_group){
-	Lattice corrected_lattice = symmetrize(noisy_structure.lattice(), enforced_factor_group);
-	Structure structure_with_correct_lattice = noisy_structure;
-	structure_with_correct_lattice.set_lattice(corrected_lattice,FRAC);
-	std::cout << "about to use basicstructuretools::symmetrize" << std::endl;
-	return CASM::xtal::symmetrize(structure_with_correct_lattice.__get<CASM::xtal::BasicStructure>(),enforced_factor_group);
+Structure symmetrize(const Structure& noisy_structure, const std::vector<sym::CartOp>& enforced_factor_group)
+{
+    Lattice corrected_lattice = symmetrize(noisy_structure.lattice(), enforced_factor_group);
+    Structure structure_with_correct_lattice = noisy_structure;
+    structure_with_correct_lattice.set_lattice(corrected_lattice, FRAC);
+    std::cout << "about to use basicstructuretools::symmetrize" << std::endl;
+    return CASM::xtal::symmetrize(structure_with_correct_lattice.__get<CASM::xtal::BasicStructure>(),
+                                  enforced_factor_group);
 }
 } // namespace xtal
 } // namespace casmutils

--- a/lib/casmutils/xtal/symmetry.cxx
+++ b/lib/casmutils/xtal/symmetry.cxx
@@ -17,5 +17,11 @@ std::vector<sym::CartOp> make_factor_group(const Structure& struc, double tol)
 {
     return CASM::xtal::make_factor_group(struc.__get<CASM::xtal::BasicStructure>(), tol);
 }
+
+
+Lattice symmetrize(const Lattice& noisy_lattice, const std::vector<sym::CartOp>& enforced_point_group){
+	return CASM::xtal::symmetrize(noisy_lattice.__get(),enforced_point_group);	
+}
+
 } // namespace xtal
 } // namespace casmutils

--- a/lib/casmutils/xtal/symmetry.cxx
+++ b/lib/casmutils/xtal/symmetry.cxx
@@ -28,7 +28,6 @@ Structure symmetrize(const Structure& noisy_structure, const std::vector<sym::Ca
     Lattice corrected_lattice = symmetrize(noisy_structure.lattice(), enforced_factor_group);
     Structure structure_with_correct_lattice = noisy_structure;
     structure_with_correct_lattice.set_lattice(corrected_lattice, FRAC);
-    std::cout << "about to use basicstructuretools::symmetrize" << std::endl;
     return CASM::xtal::symmetrize(structure_with_correct_lattice.__get<CASM::xtal::BasicStructure>(),
                                   enforced_factor_group);
 }

--- a/lib/casmutils/xtal/symmetry.cxx
+++ b/lib/casmutils/xtal/symmetry.cxx
@@ -18,9 +18,9 @@ std::vector<sym::CartOp> make_factor_group(const Structure& struc, double tol)
     return CASM::xtal::make_factor_group(struc.__get<CASM::xtal::BasicStructure>(), tol);
 }
 
-
-Lattice symmetrize(const Lattice& noisy_lattice, const std::vector<sym::CartOp>& enforced_point_group){
-	return CASM::xtal::symmetrize(noisy_lattice.__get(),enforced_point_group);	
+Lattice symmetrize(const Lattice& noisy_lattice, const std::vector<sym::CartOp>& enforced_point_group)
+{
+    return CASM::xtal::symmetrize(noisy_lattice.__get(), enforced_point_group);
 }
 
 } // namespace xtal

--- a/lib/casmutils/xtal/symmetry.cxx
+++ b/lib/casmutils/xtal/symmetry.cxx
@@ -23,5 +23,12 @@ Lattice symmetrize(const Lattice& noisy_lattice, const std::vector<sym::CartOp>&
     return CASM::xtal::symmetrize(noisy_lattice.__get(), enforced_point_group);
 }
 
+Structure symmetrize(const Structure& noisy_structure, const std::vector<sym::CartOp>& enforced_factor_group){
+	Lattice corrected_lattice = symmetrize(noisy_structure.lattice(), enforced_factor_group);
+	Structure structure_with_correct_lattice = noisy_structure;
+	structure_with_correct_lattice.set_lattice(corrected_lattice,FRAC);
+	std::cout << "about to use basicstructuretools::symmetrize" << std::endl;
+	return CASM::xtal::symmetrize(structure_with_correct_lattice.__get<CASM::xtal::BasicStructure>(),enforced_factor_group);
+}
 } // namespace xtal
 } // namespace casmutils

--- a/tests/py/casmutils/xtal/symmetry.py.in
+++ b/tests/py/casmutils/xtal/symmetry.py.in
@@ -15,6 +15,10 @@ class SymmetryGroupsTest(unittest.TestCase):
         self.cubic_lat=cu.xtal.Lattice([3,0,0],[0,3,0],[0,0,3])
         self.tet_lat=cu.xtal.Lattice([3,0,0],[0,3,0],[0,0,4])
         self.tol=1e-10;
+        hcp_mg_path=os.path.join(input_file_dir,"Mg_hcp.vasp")
+        self.hcp_mg=cu.xtal.Structure.from_poscar(hcp_mg_path)
+        almost_hcp_mg_path=os.path.join(input_file_dir,"distorted_Mg_hcp.vasp")
+        self.almost_hcp_mg=cu.xtal.Structure.from_poscar(almost_hcp_mg_path)
 
     def test_make_point_group(self):
         pg=cu.xtal.symmetry.make_point_group(self.prim_fcc_ni.lattice(),self.tol)
@@ -29,6 +33,13 @@ class SymmetryGroupsTest(unittest.TestCase):
        sym_cube_lat=cu.xtal.symmetry.symmetrize(self.tet_lat, cu.xtal.symmetry.make_point_group(self.cubic_lat,self.tol)) 
        self.assertEqual(len(cu.xtal.symmetry.make_point_group(sym_cube_lat,self.tol)),48)
 
+    def test_structure_symmetrize(self):
+        hcp_fg = cu.xtal.symmetry.make_factor_group(self.hcp_mg,1e-5)
+        symmetrized_struc = cu.xtal.symmetry.symmetrize(self.almost_hcp_mg,hcp_fg)
+        symm_fg = cu.xtal.symmetry.make_factor_group(symmetrized_struc,1e-5)
+        self.assertFalse(len(cu.xtal.symmetry.make_factor_group(self.almost_hcp_mg,1e-5))==24)
+        self.assertEqual(len(hcp_fg),24)
+        self.assertEqual(len(symm_fg),24)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/py/casmutils/xtal/symmetry.py.in
+++ b/tests/py/casmutils/xtal/symmetry.py.in
@@ -12,6 +12,8 @@ class SymmetryGroupsTest(unittest.TestCase):
     def setUp(self):
         prim_fcc_ni_path=os.path.join(input_file_dir,"primitive_fcc_Ni.vasp")
         self.prim_fcc_ni=cu.xtal.Structure.from_poscar(prim_fcc_ni_path)
+        self.cubic_lat=cu.xtal.Lattice([3,0,0],[0,3,0],[0,0,3])
+        self.tet_lat=cu.xtal.Lattice([3,0,0],[0,3,0],[0,0,4])
         self.tol=1e-10;
 
     def test_make_point_group(self):
@@ -21,6 +23,11 @@ class SymmetryGroupsTest(unittest.TestCase):
     def test_make_factor_group(self):
         fg=cu.xtal.symmetry.make_factor_group(self.prim_fcc_ni,self.tol)
         self.assertEqual(len(fg),48);
+
+    def test_lattice_symmetrize(self):
+       self.assertEqual(len(cu.xtal.symmetry.make_point_group(self.tet_lat,self.tol)),16)
+       sym_cube_lat=cu.xtal.symmetry.symmetrize(self.tet_lat, cu.xtal.symmetry.make_point_group(self.cubic_lat,self.tol)) 
+       self.assertEqual(len(cu.xtal.symmetry.make_point_group(sym_cube_lat,self.tol)),48)
 
 
 if __name__ == '__main__':

--- a/tests/py/casmutils/xtal/symmetry.py.in
+++ b/tests/py/casmutils/xtal/symmetry.py.in
@@ -28,18 +28,31 @@ class SymmetryGroupsTest(unittest.TestCase):
         fg=cu.xtal.symmetry.make_factor_group(self.prim_fcc_ni,self.tol)
         self.assertEqual(len(fg),48);
 
+class SymmetrizeTest(unittest.TestCase):
+
+    def setUp(self):
+        self.cubic_lat=cu.xtal.Lattice([3,0,0],[0,3,0],[0,0,3])
+        self.tet_lat=cu.xtal.Lattice([3,0,0],[0,3,0],[0,0,4])
+        self.tol = 1e-5
+        hcp_mg_path=os.path.join(input_file_dir,"Mg_hcp.vasp")
+        self.hcp_mg=cu.xtal.Structure.from_poscar(hcp_mg_path)
+        almost_hcp_mg_path=os.path.join(input_file_dir,"distorted_Mg_hcp.vasp")
+        self.almost_hcp_mg=cu.xtal.Structure.from_poscar(almost_hcp_mg_path)
+
     def test_lattice_symmetrize(self):
-       self.assertEqual(len(cu.xtal.symmetry.make_point_group(self.tet_lat,self.tol)),16)
-       sym_cube_lat=cu.xtal.symmetry.symmetrize(self.tet_lat, cu.xtal.symmetry.make_point_group(self.cubic_lat,self.tol)) 
-       self.assertEqual(len(cu.xtal.symmetry.make_point_group(sym_cube_lat,self.tol)),48)
+        self.assertEqual(len(cu.xtal.symmetry.make_point_group(self.tet_lat,self.tol)),16)
+        sym_cube_lat=cu.xtal.symmetry.symmetrize(self.tet_lat, cu.xtal.symmetry.make_point_group(self.cubic_lat,self.tol)) 
+        self.assertEqual(len(cu.xtal.symmetry.make_point_group(sym_cube_lat,self.tol)),48)
 
     def test_structure_symmetrize(self):
-        hcp_fg = cu.xtal.symmetry.make_factor_group(self.hcp_mg,1e-5)
+        hcp_fg = cu.xtal.symmetry.make_factor_group(self.hcp_mg,self.tol)
         symmetrized_struc = cu.xtal.symmetry.symmetrize(self.almost_hcp_mg,hcp_fg)
-        symm_fg = cu.xtal.symmetry.make_factor_group(symmetrized_struc,1e-5)
-        self.assertFalse(len(cu.xtal.symmetry.make_factor_group(self.almost_hcp_mg,1e-5))==24)
+        symm_fg = cu.xtal.symmetry.make_factor_group(symmetrized_struc,self.tol)
+        self.assertFalse(len(cu.xtal.symmetry.make_factor_group(self.almost_hcp_mg,self.tol))==24)
         self.assertEqual(len(hcp_fg),24)
         self.assertEqual(len(symm_fg),24)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/casmutils/xtal/symmetry.cpp
+++ b/tests/unit/casmutils/xtal/symmetry.cpp
@@ -26,24 +26,22 @@ protected:
 
 class SymmetrizeTest : public testing::Test
 {
-	protected:
-		using Lattice = cu::xtal::Lattice;
+protected:
+    using Lattice = cu::xtal::Lattice;
 
-		void SetUp() override
-		{
-			Eigen::Matrix3d cubic_lat_matrix = 3*Eigen::Matrix3d::Identity();
-			Eigen::Matrix3d tetragonal_lat_matrix = cubic_lat_matrix;
-			tetragonal_lat_matrix(2,2)=4;
-			cubic_lat_ptr = std::make_unique<Lattice>(cubic_lat_matrix);
-			tetragonal_lat_ptr = std::make_unique<Lattice>(tetragonal_lat_matrix);
-		
-		}
-		
-		std::unique_ptr<Lattice> cubic_lat_ptr;
-		std::unique_ptr<Lattice> tetragonal_lat_ptr;
-		double tol = 1e-10;
+    void SetUp() override
+    {
+        Eigen::Matrix3d cubic_lat_matrix = 3 * Eigen::Matrix3d::Identity();
+        Eigen::Matrix3d tetragonal_lat_matrix = cubic_lat_matrix;
+        tetragonal_lat_matrix(2, 2) = 4;
+        cubic_lat_ptr = std::make_unique<Lattice>(cubic_lat_matrix);
+        tetragonal_lat_ptr = std::make_unique<Lattice>(tetragonal_lat_matrix);
+    }
+
+    std::unique_ptr<Lattice> cubic_lat_ptr;
+    std::unique_ptr<Lattice> tetragonal_lat_ptr;
+    double tol = 1e-10;
 };
-
 
 TEST_F(CrystalGroupTest, PointGroupSize)
 {
@@ -59,11 +57,11 @@ TEST_F(CrystalGroupTest, FactorGroupSize)
 
 TEST_F(SymmetrizeTest, LatticeSymmetrize)
 {
-	std::vector<cu::sym::CartOp> cubic_point_group = cu::xtal::make_point_group(*cubic_lat_ptr,tol);
-	cu::xtal::Lattice symmetrized_tetragonal_lattice = cu::xtal::symmetrize(*tetragonal_lat_ptr, cubic_point_group);
-	std::vector<cu::sym::CartOp> symmetrized_tetragonal_point_group = cu::xtal::make_point_group(symmetrized_tetragonal_lattice,tol);	 
-	EXPECT_EQ(cubic_point_group.size(),symmetrized_tetragonal_point_group.size());
-
+    std::vector<cu::sym::CartOp> cubic_point_group = cu::xtal::make_point_group(*cubic_lat_ptr, tol);
+    cu::xtal::Lattice symmetrized_tetragonal_lattice = cu::xtal::symmetrize(*tetragonal_lat_ptr, cubic_point_group);
+    std::vector<cu::sym::CartOp> symmetrized_tetragonal_point_group =
+        cu::xtal::make_point_group(symmetrized_tetragonal_lattice, tol);
+    EXPECT_EQ(cubic_point_group.size(), symmetrized_tetragonal_point_group.size());
 }
 int main(int argc, char** argv)
 {

--- a/tests/unit/casmutils/xtal/symmetry.cpp
+++ b/tests/unit/casmutils/xtal/symmetry.cpp
@@ -24,6 +24,27 @@ protected:
     double tol = 1e-10;
 };
 
+class SymmetrizeTest : public testing::Test
+{
+	protected:
+		using Lattice = cu::xtal::Lattice;
+
+		void SetUp() override
+		{
+			Eigen::Matrix3d cubic_lat_matrix = 3*Eigen::Matrix3d::Identity();
+			Eigen::Matrix3d tetragonal_lat_matrix = cubic_lat_matrix;
+			tetragonal_lat_matrix(2,2)=4;
+			cubic_lat_ptr = std::make_unique<Lattice>(cubic_lat_matrix);
+			tetragonal_lat_ptr = std::make_unique<Lattice>(tetragonal_lat_matrix);
+		
+		}
+		
+		std::unique_ptr<Lattice> cubic_lat_ptr;
+		std::unique_ptr<Lattice> tetragonal_lat_ptr;
+		double tol = 1e-10;
+};
+
+
 TEST_F(CrystalGroupTest, PointGroupSize)
 {
     std::vector<cu::sym::CartOp> point_group = cu::xtal::make_point_group(primitive_fcc_Ni_ptr->lattice(), tol);
@@ -36,6 +57,14 @@ TEST_F(CrystalGroupTest, FactorGroupSize)
     EXPECT_EQ(factor_group.size(), 48);
 }
 
+TEST_F(SymmetrizeTest, LatticeSymmetrize)
+{
+	std::vector<cu::sym::CartOp> cubic_point_group = cu::xtal::make_point_group(*cubic_lat_ptr,tol);
+	cu::xtal::Lattice symmetrized_tetragonal_lattice = cu::xtal::symmetrize(*tetragonal_lat_ptr, cubic_point_group);
+	std::vector<cu::sym::CartOp> symmetrized_tetragonal_point_group = cu::xtal::make_point_group(symmetrized_tetragonal_lattice,tol);	 
+	EXPECT_EQ(cubic_point_group.size(),symmetrized_tetragonal_point_group.size());
+
+}
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/tests/unit/casmutils/xtal/symmetry.cpp
+++ b/tests/unit/casmutils/xtal/symmetry.cpp
@@ -28,6 +28,7 @@ class SymmetrizeTest : public testing::Test
 {
 protected:
     using Lattice = cu::xtal::Lattice;
+    using Structure = cu::xtal::Structure;
 
     void SetUp() override
     {
@@ -36,11 +37,21 @@ protected:
         tetragonal_lat_matrix(2, 2) = 4;
         cubic_lat_ptr = std::make_unique<Lattice>(cubic_lat_matrix);
         tetragonal_lat_ptr = std::make_unique<Lattice>(tetragonal_lat_matrix);
+
+
+        cu::fs::path hcp_path(cu::autotools::input_filesdir / "Mg_hcp.vasp");
+        hcp_Mg_ptr = std::make_unique<Structure>(Structure::from_poscar(hcp_path));
+
+        cu::fs::path almost_hcp_path(cu::autotools::input_filesdir / "distorted_Mg_hcp.vasp");
+        almost_hcp_Mg_ptr = std::make_unique<Structure>(Structure::from_poscar(almost_hcp_path));
+
     }
 
     std::unique_ptr<Lattice> cubic_lat_ptr;
     std::unique_ptr<Lattice> tetragonal_lat_ptr;
-    double tol = 1e-10;
+    std::unique_ptr<Structure> hcp_Mg_ptr;
+    std::unique_ptr<Structure> almost_hcp_Mg_ptr;
+    double tol = 1e-5;
 };
 
 TEST_F(CrystalGroupTest, PointGroupSize)
@@ -62,6 +73,14 @@ TEST_F(SymmetrizeTest, LatticeSymmetrize)
     std::vector<cu::sym::CartOp> symmetrized_tetragonal_point_group =
         cu::xtal::make_point_group(symmetrized_tetragonal_lattice, tol);
     EXPECT_EQ(cubic_point_group.size(), symmetrized_tetragonal_point_group.size());
+}
+TEST_F(SymmetrizeTest, StructureSymmetrize)
+{
+	std::vector<cu::sym::CartOp> hcp_factor_group = cu::xtal::make_factor_group(*hcp_Mg_ptr,tol);
+	EXPECT_NE(cu::xtal::make_factor_group(*almost_hcp_Mg_ptr,tol).size(),hcp_factor_group.size());
+	cu::xtal::Structure symmetrized_structure = cu::xtal::symmetrize(*almost_hcp_Mg_ptr,hcp_factor_group);
+	std::vector<cu::sym::CartOp> sym_distorted_factor_group = cu::xtal::make_factor_group(symmetrized_structure,tol);
+	EXPECT_EQ(sym_distorted_factor_group.size(),hcp_factor_group.size());
 }
 int main(int argc, char** argv)
 {

--- a/tests/unit/casmutils/xtal/symmetry.cpp
+++ b/tests/unit/casmutils/xtal/symmetry.cpp
@@ -38,13 +38,11 @@ protected:
         cubic_lat_ptr = std::make_unique<Lattice>(cubic_lat_matrix);
         tetragonal_lat_ptr = std::make_unique<Lattice>(tetragonal_lat_matrix);
 
-
         cu::fs::path hcp_path(cu::autotools::input_filesdir / "Mg_hcp.vasp");
         hcp_Mg_ptr = std::make_unique<Structure>(Structure::from_poscar(hcp_path));
 
         cu::fs::path almost_hcp_path(cu::autotools::input_filesdir / "distorted_Mg_hcp.vasp");
         almost_hcp_Mg_ptr = std::make_unique<Structure>(Structure::from_poscar(almost_hcp_path));
-
     }
 
     std::unique_ptr<Lattice> cubic_lat_ptr;
@@ -76,11 +74,11 @@ TEST_F(SymmetrizeTest, LatticeSymmetrize)
 }
 TEST_F(SymmetrizeTest, StructureSymmetrize)
 {
-	std::vector<cu::sym::CartOp> hcp_factor_group = cu::xtal::make_factor_group(*hcp_Mg_ptr,tol);
-	EXPECT_NE(cu::xtal::make_factor_group(*almost_hcp_Mg_ptr,tol).size(),hcp_factor_group.size());
-	cu::xtal::Structure symmetrized_structure = cu::xtal::symmetrize(*almost_hcp_Mg_ptr,hcp_factor_group);
-	std::vector<cu::sym::CartOp> sym_distorted_factor_group = cu::xtal::make_factor_group(symmetrized_structure,tol);
-	EXPECT_EQ(sym_distorted_factor_group.size(),hcp_factor_group.size());
+    std::vector<cu::sym::CartOp> hcp_factor_group = cu::xtal::make_factor_group(*hcp_Mg_ptr, tol);
+    EXPECT_NE(cu::xtal::make_factor_group(*almost_hcp_Mg_ptr, tol).size(), hcp_factor_group.size());
+    cu::xtal::Structure symmetrized_structure = cu::xtal::symmetrize(*almost_hcp_Mg_ptr, hcp_factor_group);
+    std::vector<cu::sym::CartOp> sym_distorted_factor_group = cu::xtal::make_factor_group(symmetrized_structure, tol);
+    EXPECT_EQ(sym_distorted_factor_group.size(), hcp_factor_group.size());
 }
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
This PR adds C++ implementation, tests, python implementation, and tests for the symmetrization of lattices and structures
Currently the only interface for this function is the 
Lattice symmetrize( Lattice, point_group) 
Structure symmetrize( Structure, factor_group) 
More overloads for convenience might be added in the future. 