### PR TITLE
Resolved conflicts with 0.4.X casm

### DIFF
--- a/include/casmutils/mapping/structure_mapping.hpp
+++ b/include/casmutils/mapping/structure_mapping.hpp
@@ -25,10 +25,10 @@ struct MappingReport
           stretch(casm_mapping_node.stretch()),
           translation(casm_mapping_node.translation()),
           displacement(casm_mapping_node.atom_displacement),
-          reference_lattice(casm_mapping_node.lat_node.parent.superlattice()),
-          mapped_lattice(casm_mapping_node.lat_node.child.superlattice()),
-          lattice_cost(casm_mapping_node.lat_node.cost),
-          basis_cost(casm_mapping_node.basis_node.cost),
+          reference_lattice(casm_mapping_node.lattice_node.parent.superlattice()),
+          mapped_lattice(casm_mapping_node.lattice_node.child.superlattice()),
+          lattice_cost(casm_mapping_node.lattice_node.cost),
+          basis_cost(casm_mapping_node.atomic_node.cost),
           cost(casm_mapping_node.cost)
     {
         std::vector<int> p(casm_mapping_node.atom_permutation.begin(), casm_mapping_node.atom_permutation.end());
@@ -177,7 +177,6 @@ std::pair<double, double> structure_score(const mapping::MappingReport& mapping_
 /// Map a single structure onto a reference structure with default settings
 std::vector<mapping::MappingReport> map_structure(const xtal::Structure& map_reference_struc,
                                                   const xtal::Structure& mappable_struc);
-
 } // namespace mapping
 } // namespace casmutils
 #endif

--- a/lib/casmutils/mapping/structure_mapping.cxx
+++ b/lib/casmutils/mapping/structure_mapping.cxx
@@ -7,6 +7,37 @@ namespace casmutils
 {
 namespace mapping
 {
+
+namespace
+{
+double atomic_cost_child(const MappingReport& mapped_result, int Nsites)
+{
+    Nsites = std::max(Nsites, int(1));
+    double atomic_vol = mapped_result.reference_lattice.volume() / double(Nsites) / mapped_result.stretch.determinant();
+    return pow(3. * abs(atomic_vol) / (4. * M_PI), -2. / 3.) *
+           (mapped_result.stretch.inverse() * mapped_result.displacement).squaredNorm() / double(Nsites);
+}
+//*******************************************************************************************
+
+double atomic_cost_parent(const MappingReport& mapped_result, int Nsites)
+{
+    Nsites = std::max(Nsites, int(1));
+    // mean square displacement distance in deformed coordinate system
+    double atomic_vol = mapped_result.reference_lattice.volume() / double(Nsites);
+    return pow(3. * abs(atomic_vol) / (4. * M_PI), -2. / 3.) * (mapped_result.displacement).squaredNorm() /
+           double(Nsites);
+}
+
+//*******************************************************************************************
+
+double atomic_cost(const MappingReport& mapped_result, int Nsites)
+{
+    // mean square displacement distance in deformed coordinate system
+    return (atomic_cost_child(mapped_result, Nsites) + atomic_cost_parent(mapped_result, Nsites)) / 2.;
+}
+
+} // namespace
+
 std::vector<sym::CartOp> StructureMapper_f::make_default_factor_group() const
 {
     if (this->settings.use_crystal_symmetry)
@@ -101,12 +132,8 @@ std::vector<mapping::MappingReport> map_structure(const xtal::Structure& map_ref
 
 std::pair<double, double> structure_score(const mapping::MappingReport& mapping_data)
 {
-    double lattice_score = CASM::xtal::StrainCostCalculator::iso_strain_cost(
-        mapping_data.stretch,
-        mapping_data.mapped_lattice.column_vector_matrix().determinant() /
-            std::max(int(mapping_data.permutation.size()), 1));
-    double basis_score = (mapping_data.stretch.inverse() * mapping_data.displacement).squaredNorm() /
-                         double(std::max(int(mapping_data.permutation.size()), 1));
+    double lattice_score = CASM::xtal::StrainCostCalculator::isotropic_strain_cost(mapping_data.stretch);
+    double basis_score = atomic_cost(mapping_data, std::max(int(mapping_data.permutation.size()), 1));
     return std::make_pair(lattice_score, basis_score);
 }
 

--- a/tests/py/casmutils/mapping/mapping.py.in
+++ b/tests/py/casmutils/mapping/mapping.py.in
@@ -57,7 +57,7 @@ class StructureMapTest(unittest.TestCase):
             displacement_report)
 
         self.assertAlmostEqual(lattice_score, 0, delta=1e-10)
-        self.assertAlmostEqual(basis_score, 0.08, delta=1e-10)
+        self.assertAlmostEqual(basis_score, 0.0327393, delta=1e-5)
 
 
 class MgGammaSurfaceMapTest(unittest.TestCase):
@@ -126,11 +126,11 @@ class MgGammaSurfaceMapTest(unittest.TestCase):
         map_to_hcp_super_with_sym = cu.mapping.structure.StructureMapper(
             hcp_super, k=0, use_crystal_symmetry=True, min_cost=1e-10)
 
-        self.assertEqual(3,len(map_to_hcp_super_with_sym(hcp_super)))
+        self.assertEqual(1, len(map_to_hcp_super_with_sym(hcp_super)))
 
         map_to_hcp_super_without_sym = cu.mapping.structure.StructureMapper(
             hcp_super, k=0, use_crystal_symmetry=False, min_cost=1e-10)
-        self.assertEqual(72,len(map_to_hcp_super_without_sym(hcp_super)))
+        self.assertEqual(72, len(map_to_hcp_super_without_sym(hcp_super)))
 
         return
 

--- a/tests/unit/casmutils/mapping/structure_mapping.cpp
+++ b/tests/unit/casmutils/mapping/structure_mapping.cpp
@@ -62,8 +62,6 @@ TEST_F(StructureMapTest, BainMappingScore)
     auto [perfect_bain_lattice_score, perfect_bain_basis_score] = cu::mapping::structure_score(perfect_bain_report);
 
     // lattice score should be finite and identical for bcc and fully bained no matter the volume
-    std::cout << "DEBUGGING: full_bain_lattice_score " << full_bain_lattice_score << std::endl;
-    std::cout << "DEBUGGING: perfect_bain_lattice_score " << perfect_bain_lattice_score << std::endl;
     EXPECT_TRUE(std::abs(full_bain_lattice_score - perfect_bain_lattice_score) < 1e-10);
     // partially bained fcc should have a lower score than bcc
     EXPECT_TRUE(full_bain_lattice_score > partial_bain_lattice_score);

--- a/tests/unit/casmutils/mapping/structure_mapping.cpp
+++ b/tests/unit/casmutils/mapping/structure_mapping.cpp
@@ -1,6 +1,7 @@
 // These are classes that structure_tools depends on
 #include "../../../autotools.hh"
 #include <algorithm>
+#include <casmutils/misc.hpp>
 #include <casmutils/xtal/structure.hpp>
 #include <casmutils/xtal/structure_tools.hpp>
 #include <casmutils/xtal/symmetry.hpp>
@@ -11,6 +12,7 @@
 // This file tests the functions in:
 #include <casmutils/mapping/structure_mapping.hpp>
 #include <limits>
+#include <math.h>
 #include <string>
 #include <utility>
 #include <vector>
@@ -60,6 +62,8 @@ TEST_F(StructureMapTest, BainMappingScore)
     auto [perfect_bain_lattice_score, perfect_bain_basis_score] = cu::mapping::structure_score(perfect_bain_report);
 
     // lattice score should be finite and identical for bcc and fully bained no matter the volume
+    std::cout << "DEBUGGING: full_bain_lattice_score " << full_bain_lattice_score << std::endl;
+    std::cout << "DEBUGGING: perfect_bain_lattice_score " << perfect_bain_lattice_score << std::endl;
     EXPECT_TRUE(std::abs(full_bain_lattice_score - perfect_bain_lattice_score) < 1e-10);
     // partially bained fcc should have a lower score than bcc
     EXPECT_TRUE(full_bain_lattice_score > partial_bain_lattice_score);
@@ -76,7 +80,7 @@ TEST_F(StructureMapTest, DisplacementMappingScore)
         cu::mapping::map_structure(*primitive_fcc_Ni_ptr, *displaced_fcc_Ni_ptr)[0];
     auto [lattice_score, basis_score] = cu::mapping::structure_score(displacement_report);
     EXPECT_TRUE(std::abs(lattice_score) < 1e-10);
-    EXPECT_TRUE(std::abs(basis_score - 0.08) < 1e-10);
+    EXPECT_TRUE(std::abs(basis_score - 0.0327393) < 1e-5);
 }
 
 //**********************************************************************************************
@@ -249,6 +253,7 @@ TEST_F(MgGammaSurfaceMapTest, MappingResultsSize)
 {
     cu::xtal::Structure hcp_triple = shifted_structures[0];
     auto factor_group = cu::xtal::make_factor_group(hcp_triple, 1e-5);
+    auto prim_factor_group = cu::xtal::make_factor_group(cu::xtal::make_primitive(hcp_triple), 1e-5);
     // If you don't use symmetry in the mapper, expect to get as many
     // mappings as there are factor group operations
     cu::mapping::MappingInput map_strategy;
@@ -259,7 +264,10 @@ TEST_F(MgGammaSurfaceMapTest, MappingResultsSize)
     EXPECT_EQ(blind_mapper(hcp_triple).size(), factor_group.size());
 
     cu::mapping::StructureMapper_f sym_aware_mapper(hcp_triple, map_strategy, factor_group);
-    EXPECT_EQ(sym_aware_mapper(hcp_triple).size(), 3);
+    EXPECT_EQ(sym_aware_mapper(hcp_triple).size(), 1);
+
+    cu::mapping::StructureMapper_f prim_sym_aware_mapper(hcp_triple, map_strategy, prim_factor_group);
+    EXPECT_EQ(prim_sym_aware_mapper(hcp_triple).size(), 3);
 }
 
 TEST_F(MgGammaSurfaceMapTest, SelfMapResultsSize)
@@ -274,7 +282,7 @@ TEST_F(MgGammaSurfaceMapTest, SelfMapResultsSize)
     cu::mapping::StructureMapper_f map_to_hcp_super_with_sym(hcp_super, map_strategy);
     // When using crystal symmetry, the mapper should only find as many mappings as primitives
     // fit in the structure
-    EXPECT_EQ(3, map_to_hcp_super_with_sym(hcp_super).size());
+    EXPECT_EQ(1, map_to_hcp_super_with_sym(hcp_super).size());
 
     map_strategy.use_crystal_symmetry = false;
     cu::mapping::StructureMapper_f map_to_hcp_super_without_sym(hcp_super, map_strategy);


### PR DESCRIPTION
-- Resolved conflicts with 0.4.X casm
-- This also includes the atomic cost function @skk74 after conflicts with JCT's symmetric mapping stuff.

