### PR TITLE
Nuked Coordinate class out of existence 

### DIFF
--- a/include/casmutils/misc.hpp
+++ b/include/casmutils/misc.hpp
@@ -21,6 +21,7 @@ namespace casmutils
 {
 using CASM::almost_equal;
 using CASM::almost_zero;
+
 template <typename ComparatorType_f, typename CompareType, typename... Args>
 bool is_equal(const CompareType& reference, const CompareType& other, const Args&... functor_params)
 {
@@ -41,10 +42,10 @@ bool is_equal(const CompareType& reference, const CompareType& other, const Args
 namespace extend
 {
 /// Make a PrimClex but shut up about it
-CASM::PrimClex quiet_primclex(CASM::xtal::Structure& prim);
+// CASM::PrimClex quiet_primclex(CASM::xtal::Structure& prim);
 
 /// Alternate construction of a site with only occupant degrees of freedom, and atom as occuapnt (no molecule)
-CASM::xtal::Site atomic_site(const CASM::xtal::Coordinate& coord, const std::vector<std::string>& allowed_species);
+// CASM::xtal::Site atomic_site(const CASM::xtal::Coordinate& coord, const std::vector<std::string>& allowed_species);
 } // namespace extend
 
 namespace io

--- a/include/casmutils/xtal/coordinate.hpp
+++ b/include/casmutils/xtal/coordinate.hpp
@@ -19,11 +19,11 @@ namespace coordinate
  */
 
 /// Returns cartesian coordinates when fractional coordinates are given
-Eigen::Vector3d get_cartesian_coordinates_from_fractional(const Eigen::Vector3d& fractional_coordinate,
+Eigen::Vector3d fractional_to_cartesian(const Eigen::Vector3d& fractional_coordinate,
                                                           const Lattice& lat);
 
 /// Returns fractional coordinates when cartesian coordinates are given
-Eigen::Vector3d get_fractional_coordinates(const Eigen::Vector3d& cartesian_coordinate, const Lattice& lat);
+Eigen::Vector3d cartesian_to_fractional(const Eigen::Vector3d& cartesian_coordinate, const Lattice& lat);
 
 /// Brings the given cartesian coordinate within the given lattice
 Eigen::Vector3d bring_within_lattice(const Eigen::Vector3d& cartesian_coordinate, const Lattice& lat);

--- a/include/casmutils/xtal/coordinate.hpp
+++ b/include/casmutils/xtal/coordinate.hpp
@@ -10,59 +10,28 @@ namespace xtal
 {
 
 class Lattice;
-
-// TODO: Just erase this class, it's super annoying. You can do all of this
-// stuff with functions
-
+namespace coordinate
+{
 /**
  * The rewrap version of Coordinate does *not* have a home Lattice,
  * and instead is always set to CART mode. Any routines that involve
  * a lattice require passing it as an argument.
  */
 
-class Coordinate
-{
-public:
-    Coordinate() = delete;
-    Coordinate(const CASM::xtal::Coordinate& init_coord) : casm_coord(init_coord) {}
-    Coordinate(const Eigen::Vector3d& cart_coord)
-        : Coordinate(CASM::xtal::Coordinate(cart_coord, CASM::xtal::Lattice(), CASM::CART)){};
-    Coordinate(double x, double y, double z) : Coordinate(Eigen::Vector3d(x, y, z)) {}
+/// Returns cartesian coordinates when fractional coordinates are given
+Eigen::Vector3d get_cartesian_coordinates_from_fractional(const Eigen::Vector3d& fractional_coordinate,
+                                                          const Lattice& lat);
 
-    /// Initialize the Coordinate by providing fractional coordinates and the corresponding lattice
-    static Coordinate from_fractional(const Eigen::Vector3d& frac_coord, const Lattice& lat);
-    static Coordinate from_fractional(double x, double y, double z, const Lattice& lat);
+/// Returns fractional coordinates when cartesian coordinates are given
+Eigen::Vector3d get_fractional_coordinates(const Eigen::Vector3d& cartesian_coordinate, const Lattice& lat);
 
-    /// Retreive the Cartesian values of the coordinate
-    Eigen::Vector3d cart() const;
-    /// Retreive the fractional values of the coordinate relative to the provided lattice
-    Eigen::Vector3d frac(const Lattice& ref_lattice) const;
+/// Brings the given cartesian coordinate within the given lattice
+Eigen::Vector3d bring_within_lattice(const Eigen::Vector3d& cartesian_coordinate, const Lattice& lat);
 
-    Coordinate operator+(const Coordinate& coord_to_add) const;
-    /// Translate *this by the given coordinate
-    Coordinate& operator+=(const Coordinate& coord_to_add);
+/// Brings the given cartesian coordinates within the wigner seitz cell of the given lattice
+Eigen::Vector3d bring_within_wigner_seitz(const Eigen::Vector3d& cartesian_coordinate, const Lattice& lat);
 
-    // TODO: These are annoying as member functions. Make them standalone.
-    // and let them accept Eigen::Vector3d as well. Same with the wigner-seitz
-    /// Bring *this within the given lattice
-    void bring_within(const Lattice& lat);
-
-    /// Bring *this within the given lattice
-    [[nodiscard]] Coordinate bring_within(const Lattice& lat) const;
-
-    /// Bring *this within the given lattice
-    void bring_within_wigner_seitz(const Lattice& lat);
-
-    /// Bring *this within the Wigner-Seitz cell of the given lattice
-    [[nodiscard]] Coordinate bring_within_wigner_seitz(const Lattice& lat) const;
-
-    /// Access  the CASM implementation within.
-    const CASM::xtal::Coordinate& __get() const { return casm_coord; };
-
-private:
-    /// Use the CASM implementation to forward any functionality you want
-    CASM::xtal::Coordinate casm_coord;
-};
+} // namespace coordinate
 
 // TODO: make this binary, not unary (same with all other comparators)
 struct CoordinateEquals_f
@@ -70,12 +39,12 @@ struct CoordinateEquals_f
     /// for casmutils::xtal::Coordinate
 public:
     /// Determines whether test is equal to reference site with a tolerance
-    CoordinateEquals_f(const Coordinate& ref_coordinate, double tol);
+    CoordinateEquals_f(const Eigen::Vector3d& ref_coordinate, double tol);
     /// Returns true if other is equal to the Coordinate the comparator was constructed with
-    bool operator()(const Coordinate& other);
+    bool operator()(const Eigen::Vector3d& other);
 
 private:
-    Coordinate ref_coordinate;
+    Eigen::Vector3d ref_coordinate;
     double tol;
 };
 

--- a/include/casmutils/xtal/lattice.hpp
+++ b/include/casmutils/xtal/lattice.hpp
@@ -18,7 +18,6 @@ public:
     /// Construct lattice by specifying each individual vector
     Lattice(const Eigen::Vector3d& a, const Eigen::Vector3d& b, const Eigen::Vector3d& c);
 
-
     static Lattice from_column_vector_matrix(const Eigen::Matrix3d& column_vector_matrix)
     {
         return Lattice(column_vector_matrix);
@@ -43,7 +42,6 @@ public:
                                            const double& alpha,
                                            const double& beta,
                                            const double& gamma);
-
 
     // TODO: Read up on Eigen::Matrix3d::ColXpr and decide if you prefer this. CASM does it this way.
     /// Return the ith vector of the lattice
@@ -127,17 +125,6 @@ xtal::Lattice make_superlattice(const xtal::Lattice& tiling_unit, const Eigen::M
 /// Given a lattice and a vector of integer Miller indices, return the smallest superlattice
 /// that has the a and b vectors spanning the specified plane
 xtal::Lattice slice_along_plane(const xtal::Lattice& unit_lattice, const Eigen::Vector3i& miller_indexes);
-
-/// Converts Cartesian coordinates to fractional
-Eigen::Vector3d make_fractional(const Eigen::Vector3d& cart_coord, const xtal::Lattice& lat);
-
-// TODO: Tolerance issues?
-/// Brings the given Cartesian coordinate inside the unit cell
-Eigen::Vector3d bring_within(const Eigen::Vector3d cart_coord, const xtal::Lattice& unit_cell);
-
-/// Brings the given Cartesian coordinate inside the Wigner-Seitz cell of the given unit cell
-Eigen::Vector3d bring_within_wigner_seitz(const Eigen::Vector3d cart_coord, const xtal::Lattice& unit_cell);
-
 } // namespace xtal
 } // namespace casmutils
 

--- a/include/casmutils/xtal/rocksalttoggler.hpp
+++ b/include/casmutils/xtal/rocksalttoggler.hpp
@@ -14,7 +14,7 @@ namespace enumeration
 class RockSaltOctahedraToggler
 {
 public:
-    typedef casmutils::xtal::Coordinate Coordinate;
+    typedef Eigen::Vector3d Coordinate;
     typedef casmutils::xtal::Structure Structure;
     typedef casmutils::xtal::Lattice Lattice;
     typedef int index;

--- a/include/casmutils/xtal/site.hpp
+++ b/include/casmutils/xtal/site.hpp
@@ -10,7 +10,6 @@ namespace xtal
 {
 
 class Lattice;
-class Coordinate;
 
 /**
  * A coordinate and type of species. Even though it's implemented
@@ -22,11 +21,7 @@ class Site
 public:
     Site() = delete;
     Site(const CASM::xtal::Site& init_site, int occupant);
-    Site(const Coordinate& init_coord, const std::string& occupant_name);
     Site(const Eigen::Vector3d& init_coord, const std::string& occupant_name);
-
-    /// Allow casting to Coordinate, by stripping everything away except the Cartesian position
-    operator Coordinate() const;
 
     /// Retreive the Cartesian values of the coordinate
     Eigen::Vector3d cart() const;

--- a/lib-py/casmutils/sym/_sym/sym-py.cxx
+++ b/lib-py/casmutils/sym/_sym/sym-py.cxx
@@ -1,4 +1,5 @@
 #include <casmutils/sym/cartesian.hpp>
+#include <casmutils/xtal/symmetry.hpp>
 #include <fstream>
 #include <string>
 
@@ -17,6 +18,8 @@ namespace casmutils
 namespace wrappy
 {
 using namespace casmutils;
+using casmutils::xtal::operator*;
+
 PYBIND11_MODULE(_sym, m)
 {
     using namespace pybind11;
@@ -35,7 +38,10 @@ PYBIND11_MODULE(_sym, m)
             .def_readwrite("matrix", &sym::CartOp::matrix)
             .def_readwrite("translation", &sym::CartOp::translation)
             .def_readwrite("is_time_reversal_active", &sym::CartOp::is_time_reversal_active)
-            .def(pybind11::self * pybind11::self);
+            .def(pybind11::self * pybind11::self)
+            .def("__mul__", [](const sym::CartOp& op, const Eigen::Vector3d& coord) {
+                return op * coord;
+            });
     }
 }
 } // namespace wrappy

--- a/lib-py/casmutils/xtal/_xtal/coordinate-py.cxx
+++ b/lib-py/casmutils/xtal/_xtal/coordinate-py.cxx
@@ -16,12 +16,12 @@ using namespace casmutils;
 
 namespace Coordinate
 {
-std::string __str__(const xtal::Coordinate& printable)
-{
-    std::ostringstream sstream;
-    sstream << printable.cart().transpose();
-    return sstream.str();
-}
+// std::string __str__(const xtal::Coordinate& printable)
+//{
+//    std::ostringstream sstream;
+//    sstream << printable.cart().transpose();
+//    return sstream.str();
+//}
 
 /* bool is_equal(const xtal::Coordinate& lhs, const xtal::Coordinate& rhs, double tol) */
 /* { */

--- a/lib-py/casmutils/xtal/_xtal/coordinate-py.hpp
+++ b/lib-py/casmutils/xtal/_xtal/coordinate-py.hpp
@@ -13,7 +13,7 @@ namespace wrappy
 using namespace casmutils;
 namespace Coordinate
 {
-std::string __str__(const xtal::Coordinate& printable);
+// std::string __str__(const xtal::Coordinate& printable);
 /* bool is_equal(const xtal::Coordinate& lhs, const xtal::Coordinate& rhs, double tol); */
 } // namespace Coordinate
 } // namespace wrappy

--- a/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
+++ b/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
@@ -68,9 +68,8 @@ PYBIND11_MODULE(_xtal, m)
             .def("__call__", &xtal::LatticeEquals_f::operator());
     }
 
-    m.def("get_cartesian_coordinates_from_fractional",
-          casmutils::xtal::coordinate::get_cartesian_coordinates_from_fractional);
-    m.def("get_fractional_coordinates", casmutils::xtal::coordinate::get_fractional_coordinates);
+    m.def("fractional_to_cartesian", casmutils::xtal::coordinate::fractional_to_cartesian);
+    m.def("cartesian_to_fractional", casmutils::xtal::coordinate::cartesian_to_fractional);
     m.def("bring_within_lattice", casmutils::xtal::coordinate::bring_within_lattice);
     m.def("bring_within_wigner_seitz", casmutils::xtal::coordinate::bring_within_wigner_seitz);
 

--- a/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
+++ b/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
@@ -68,29 +68,15 @@ PYBIND11_MODULE(_xtal, m)
             .def("__call__", &xtal::LatticeEquals_f::operator());
     }
 
-    {
-        using namespace wrappy::Coordinate;
-        class_<xtal::Coordinate>(m, "Coordinate")
-            .def(init<const Eigen::Vector3d&&>())
-            .def_static("from_fractional",
-                        pybind11::overload_cast<const Eigen::Vector3d&, const xtal::Lattice&>(
-                            &xtal::Coordinate::from_fractional))
-            .def("__str__", __str__)
-            .def("__add__", &xtal::Coordinate::operator+, pybind11::is_operator())
-            .def("__iadd__", &xtal::Coordinate::operator+=)
-            .def("_bring_within_const",
-                 pybind11::overload_cast<const xtal::Lattice&>(&xtal::Coordinate::bring_within, pybind11::const_))
-            .def("_bring_within", pybind11::overload_cast<const xtal::Lattice&>(&xtal::Coordinate::bring_within))
-            .def("_cart_const", &xtal::Coordinate::cart)
-            .def("_frac_const", &xtal::Coordinate::frac)
-            .def("__rmul__", [](const xtal::Coordinate& coord, const sym::CartOp& symop) {
-                return symop * coord;
-            });
-    }
+    m.def("get_cartesian_coordinates_from_fractional",
+          casmutils::xtal::coordinate::get_cartesian_coordinates_from_fractional);
+    m.def("get_fractional_coordinates", casmutils::xtal::coordinate::get_fractional_coordinates);
+    m.def("bring_within_lattice", casmutils::xtal::coordinate::bring_within_lattice);
+    m.def("bring_within_wigner_seitz", casmutils::xtal::coordinate::bring_within_wigner_seitz);
 
     {
         class_<xtal::CoordinateEquals_f>(m, "CoordinateEquals_f")
-            .def(init<xtal::Coordinate, double>())
+            .def(init<Eigen::Vector3d, double>())
             .def("__call__", &xtal::CoordinateEquals_f::operator());
     }
 
@@ -98,7 +84,6 @@ PYBIND11_MODULE(_xtal, m)
         using namespace wrappy::Site;
         class_<xtal::Site>(m, "Site")
             .def(init<const Eigen::Vector3d&, const std::string&>())
-            .def(init<const xtal::Coordinate&, const std::string&>())
             .def("__str__", __str__)
             .def("_cart_const", &xtal::Site::cart)
             .def("_frac_const", &xtal::Site::frac)
@@ -123,13 +108,13 @@ PYBIND11_MODULE(_xtal, m)
             .def("all_octahedron_center_coordinates", &RSOT::all_octahedron_center_coordinates)
             .def("to_poscar", to_poscar)
             .def("structure", &RSOT::structure)
-            .def("activate", (void (RSOT::*)(const xtal::Coordinate&)) & RSOT::activate)
+            .def("activate", (void (RSOT::*)(const Eigen::Vector3d&)) & RSOT::activate)
             .def("activate", (void (RSOT::*)(RSOT::index)) & RSOT::activate)
             .def("activate_all", &RSOT::activate_all)
-            .def("deactivate", (void (RSOT::*)(const xtal::Coordinate&)) & RSOT::deactivate)
+            .def("deactivate", (void (RSOT::*)(const Eigen::Vector3d&)) & RSOT::deactivate)
             .def("deactivate", (void (RSOT::*)(RSOT::index)) & RSOT::deactivate)
             .def("deactivate_all", &RSOT::deactivate_all)
-            .def("toggle", (void (RSOT::*)(const xtal::Coordinate&)) & RSOT::toggle)
+            .def("toggle", (void (RSOT::*)(const Eigen::Vector3d&)) & RSOT::toggle)
             .def("toggle", (void (RSOT::*)(RSOT::index)) & RSOT::toggle)
             .def("toggle_all", &RSOT::toggle_all)
             .def("nearest_neighbor_distance", &RSOT::nearest_neighbor_distance)

--- a/lib-py/casmutils/xtal/coordinate.py
+++ b/lib-py/casmutils/xtal/coordinate.py
@@ -70,7 +70,7 @@ class _Coordinate:
         np.array
 
         """
-        return _xtal.get_fractional_coordinates(self.coord, lat)
+        return _xtal.cartesian_to_fractional(self.coord, lat)
 
     @classmethod
     def from_fractional(cls, coords, lat):
@@ -87,8 +87,7 @@ class _Coordinate:
         Coordinate
 
         """
-        cartesian_coords = _xtal.get_cartesian_coordinates_from_fractional(
-            coords, lat)
+        cartesian_coords = _xtal.fractional_to_cartesian(coords, lat)
         return cls(cartesian_coords)
 
     def set_compare_method(self, method, *args):
@@ -253,3 +252,67 @@ class MutableCoordinate(_Coordinate):
         """
         self.coord = np.add(self.coord, other.cart())
         return self
+
+
+def cartesian_to_fractional(cart_coords, lat):
+    """Returs fractional coordinates of the given cartesian coordinates
+
+    Parameters
+    ----------
+    cart_coords : np.array
+    lat : cu.xtal.Lattice
+
+    Returns
+    -------
+    np.array
+
+    """
+    return _xtal.cartesian_to_fractional(cart_coords, lat)
+
+
+def fractional_to_cartesian(frac_coords, lat):
+    """Returs fractional coordinates of the given cartesian coordinates
+
+    Parameters
+    ----------
+    frac_coords: np.array
+    lat : cu.xtal.Lattice
+
+    Returns
+    -------
+    np.array
+
+    """
+    return _xtal.fractional_to_cartesian(frac_coords, lat)
+
+
+def bring_within_lattice(cart_coords, lat):
+    """Brings the given cartesian coordinates within the lattice
+
+    Parameters
+    ----------
+    cart_coords : np.array
+    lat : cu.xtal.Lattice
+
+    Returns
+    -------
+    np.array
+
+    """
+    return _xtal.bring_within_lattice(cart_coords, lat)
+
+
+def bring_within_wigner_seitz(cart_coords, lat):
+    """Brings the given cartesian coordinates within the wigner seitz cell of the lattice
+
+    Parameters
+    ----------
+    cart_coords : np.array
+    lat : cu.xtal.Lattice
+
+    Returns
+    -------
+    np.array
+
+    """
+    return _xtal.bring_within_wigner_seitz(cart_coords, lat)

--- a/lib-py/casmutils/xtal/site.py
+++ b/lib-py/casmutils/xtal/site.py
@@ -48,7 +48,7 @@ class _Site:
 
         elif type(coord).__name__ is "Coordinate" or type(
                 coord).__name__ is "MutableCoordinate":
-            self._pybind_value = _xtal.Site(coord._pybind_value, label)
+            self._pybind_value = _xtal.Site(coord.cart(), label)
 
         else:
             self._pybind_value = _xtal.Site(coord, label)

--- a/lib/casmutils/mush/shift.cxx
+++ b/lib/casmutils/mush/shift.cxx
@@ -29,7 +29,7 @@ std::vector<xtal::Structure> make_cleaved_structures(const xtal::Structure& slab
     std::vector<xtal::Structure> cleaved_structures;
     for (double cleave : cleavage_values)
     {
-        cleaved_structures.emplace_back(make_cleaved_structure(slab,cleave));
+        cleaved_structures.emplace_back(make_cleaved_structure(slab, cleave));
     }
     return cleaved_structures;
 }
@@ -37,7 +37,7 @@ std::vector<xtal::Structure> make_cleaved_structures(const xtal::Structure& slab
 xtal::Structure make_cleaved_structure(const xtal::Structure& slab, double cleavage)
 {
     // TODO: This might go astray if you get a left handed lattice, I think it'd cause negative cleavages
-    if(slab.lattice().column_vector_matrix().determinant()<0)
+    if (slab.lattice().column_vector_matrix().determinant() < 0)
     {
         throw std::runtime_error("Cannot currently cleave a left handed structure");
     }
@@ -57,7 +57,7 @@ make_uniform_in_plane_shift_vectors(const xtal::Lattice& slab_lattice, int a_max
         for (int b = 0; b < b_max; ++b)
         {
             Eigen::Vector3d frac_coord(static_cast<double>(a) / a_max, static_cast<double>(b) / b_max, 0);
-            shifts.emplace_back(xtal::make_fractional(frac_coord, slab_lattice));
+            shifts.emplace_back(xtal::coordinate::get_cartesian_coordinates_from_fractional(frac_coord, slab_lattice));
 
             records.emplace_back(a, b, ix);
             ++ix;
@@ -75,7 +75,7 @@ make_uniform_in_plane_wigner_seitz_shift_vectors(const xtal::Lattice& slab_latti
     std::vector<Eigen::Vector3d> wigner_seitz_shifts;
     for (const auto& standard_shift : standard_shifts)
     {
-        wigner_seitz_shifts.emplace_back(xtal::bring_within_wigner_seitz(standard_shift, slab_lattice));
+        wigner_seitz_shifts.emplace_back(xtal::coordinate::bring_within_wigner_seitz(standard_shift, slab_lattice));
     }
 
     return std::make_pair(wigner_seitz_shifts, std::move(standard_shifts_and_records.second));

--- a/lib/casmutils/mush/shift.cxx
+++ b/lib/casmutils/mush/shift.cxx
@@ -57,7 +57,7 @@ make_uniform_in_plane_shift_vectors(const xtal::Lattice& slab_lattice, int a_max
         for (int b = 0; b < b_max; ++b)
         {
             Eigen::Vector3d frac_coord(static_cast<double>(a) / a_max, static_cast<double>(b) / b_max, 0);
-            shifts.emplace_back(xtal::coordinate::get_cartesian_coordinates_from_fractional(frac_coord, slab_lattice));
+            shifts.emplace_back(xtal::coordinate::fractional_to_cartesian(frac_coord, slab_lattice));
 
             records.emplace_back(a, b, ix);
             ++ix;

--- a/lib/casmutils/mush/slab.cxx
+++ b/lib/casmutils/mush/slab.cxx
@@ -83,7 +83,7 @@ xtal::Lattice orthogonalize_c_vector(const xtal::Lattice& lat)
 
     // In plane component should have no c component
 
-    auto plane_component_frac = xtal::coordinate::get_fractional_coordinates(plane_component, lat);
+    auto plane_component_frac = xtal::coordinate::cartesian_to_fractional(plane_component, lat);
     assert(almost_equal(plane_component_frac(2), 0.0, 1e-8));
 
     plane_component = xtal::coordinate::bring_within_wigner_seitz(plane_component, lat);

--- a/lib/casmutils/mush/slab.cxx
+++ b/lib/casmutils/mush/slab.cxx
@@ -69,7 +69,7 @@ xtal::Structure make_aligned(xtal::Structure struc)
 
 void make_aligned(xtal::Structure* struc)
 {
-    struc->set_lattice(make_aligned(struc->lattice()),xtal::FRAC);
+    struc->set_lattice(make_aligned(struc->lattice()), xtal::FRAC);
     return;
 }
 
@@ -78,14 +78,16 @@ xtal::Lattice orthogonalize_c_vector(const xtal::Lattice& lat)
     assert(lat.column_vector_matrix().determinant() > 0);
     Eigen::Vector3d normal = lat.a().cross(lat.b()).normalized();
 
-    xtal::Coordinate ortho_component = xtal::Coordinate(lat.c().dot(normal) * normal);
-    xtal::Coordinate plane_component = xtal::Coordinate(lat.c() - ortho_component.cart());
+    Eigen::Vector3d ortho_component = lat.c().dot(normal) * normal;
+    Eigen::Vector3d plane_component = lat.c() - ortho_component;
 
     // In plane component should have no c component
-    assert(almost_equal(plane_component.frac(lat)(2), 0.0, 1e-8));
 
-    plane_component.bring_within_wigner_seitz(lat);
-    Eigen::Vector3d final_c = plane_component.cart() + ortho_component.cart();
+    auto plane_component_frac = xtal::coordinate::get_fractional_coordinates(plane_component, lat);
+    assert(almost_equal(plane_component_frac(2), 0.0, 1e-8));
+
+    plane_component = xtal::coordinate::bring_within_wigner_seitz(plane_component, lat);
+    Eigen::Vector3d final_c = plane_component + ortho_component;
     return xtal::Lattice(lat.a(), lat.b(), final_c);
 }
 

--- a/lib/casmutils/xtal/coordinate.cxx
+++ b/lib/casmutils/xtal/coordinate.cxx
@@ -7,74 +7,41 @@ namespace casmutils
 {
 namespace xtal
 {
-Coordinate Coordinate::from_fractional(const Eigen::Vector3d& frac_coord, const Lattice& lat)
+namespace coordinate
 {
-    CASM::xtal::Coordinate coord(frac_coord, lat.__get(), CASM::FRAC);
-    return Coordinate(coord);
+
+Eigen::Vector3d get_cartesian_coordinates_from_fractional(const Eigen::Vector3d& fractional_coordinates,
+                                                          const Lattice& lat)
+{
+    return CASM::xtal::Coordinate(fractional_coordinates, lat.__get(), CASM::FRAC).cart();
 }
 
-Coordinate Coordinate::from_fractional(double x, double y, double z, const Lattice& lat)
+Eigen::Vector3d get_fractional_coordinates(const Eigen::Vector3d& cartesian_coord, const Lattice& lat)
 {
-    return Coordinate::from_fractional(Eigen::Vector3d(x, y, z), lat);
+    return CASM::xtal::Coordinate(cartesian_coord, lat.__get(), CASM::CART).frac();
 }
 
-void Coordinate::bring_within(const Lattice& lat)
+Eigen::Vector3d bring_within_lattice(const Eigen::Vector3d& cartesian_coord, const Lattice& lat)
 {
-    this->casm_coord.set_lattice(lat.__get(), CASM::CART);
-    this->casm_coord.within();
-    return;
+    CASM::xtal::Coordinate casm_coord(cartesian_coord, lat.__get(), CASM::CART);
+    casm_coord.within();
+    return casm_coord.cart();
 }
 
-Coordinate Coordinate::bring_within(const Lattice& lat) const
+Eigen::Vector3d bring_within_wigner_seitz(const Eigen::Vector3d& cartesian_coord, const Lattice& lat)
 {
-    Coordinate copy_coord(*this);
-    copy_coord.bring_within(lat);
-    return copy_coord;
+    CASM::xtal::Coordinate casm_coord(cartesian_coord, lat.__get(), CASM::CART);
+    casm_coord.voronoi_within();
+    return casm_coord.cart();
 }
 
-void Coordinate::bring_within_wigner_seitz(const Lattice& lat)
-{
-    this->casm_coord.set_lattice(lat.__get(), CASM::CART);
-    this->casm_coord.voronoi_within();
-    return;
-}
+} // namespace coordinate
 
-Coordinate Coordinate::bring_within_wigner_seitz(const Lattice& lat) const
-{
-    Coordinate copy_coord(*this);
-    copy_coord.bring_within_wigner_seitz(lat);
-    return copy_coord;
-}
-
-Eigen::Vector3d Coordinate::cart() const { return this->casm_coord.cart(); }
-
-Eigen::Vector3d Coordinate::frac(const Lattice& ref_lattice) const
-{
-    const_cast<CASM::xtal::Coordinate*>(&this->casm_coord)->set_lattice(ref_lattice.__get(), CASM::CART);
-    return this->casm_coord.frac();
-}
-
-Coordinate& Coordinate::operator+=(const Coordinate& coord_to_add)
-{
-    this->casm_coord += coord_to_add.casm_coord;
-    return *this;
-}
-
-Coordinate Coordinate::operator+(const Coordinate& coord_to_add) const
-{
-    Coordinate summed_coord = *this;
-    summed_coord += coord_to_add;
-    return summed_coord;
-}
-
-CoordinateEquals_f::CoordinateEquals_f(const Coordinate& ref_coordinate, double tol)
+CoordinateEquals_f::CoordinateEquals_f(const Eigen::Vector3d& ref_coordinate, double tol)
     : ref_coordinate(ref_coordinate), tol(tol)
 {
 }
-bool CoordinateEquals_f::operator()(const Coordinate& other)
-{
-    return ref_coordinate.cart().isApprox(other.cart(), tol);
-}
+bool CoordinateEquals_f::operator()(const Eigen::Vector3d& other) { return ref_coordinate.isApprox(other, tol); }
 
 } // namespace xtal
 } // namespace casmutils

--- a/lib/casmutils/xtal/coordinate.cxx
+++ b/lib/casmutils/xtal/coordinate.cxx
@@ -10,13 +10,12 @@ namespace xtal
 namespace coordinate
 {
 
-Eigen::Vector3d get_cartesian_coordinates_from_fractional(const Eigen::Vector3d& fractional_coordinates,
-                                                          const Lattice& lat)
+Eigen::Vector3d fractional_to_cartesian(const Eigen::Vector3d& fractional_coordinates, const Lattice& lat)
 {
     return CASM::xtal::Coordinate(fractional_coordinates, lat.__get(), CASM::FRAC).cart();
 }
 
-Eigen::Vector3d get_fractional_coordinates(const Eigen::Vector3d& cartesian_coord, const Lattice& lat)
+Eigen::Vector3d cartesian_to_fractional(const Eigen::Vector3d& cartesian_coord, const Lattice& lat)
 {
     return CASM::xtal::Coordinate(cartesian_coord, lat.__get(), CASM::CART).frac();
 }

--- a/lib/casmutils/xtal/frankenstein.cxx
+++ b/lib/casmutils/xtal/frankenstein.cxx
@@ -38,12 +38,12 @@ xtal::Structure stack(std::vector<xtal::Structure> sub_strucs)
     // Even if you don't want to strain it you HAVE to ensure that the ab vectors
     // are at least aligned properly, or you're going to sum up weird stuff if you
     // feed structures that have the same ab vectors within a rigid rotation
-    for(auto& s : sub_strucs)
+    for (auto& s : sub_strucs)
     {
-        const auto& ref_lat=sub_strucs[0].lattice();
-        const auto& curr_lat=s.lattice();
-        xtal::Lattice compatible_lat(ref_lat.a(),ref_lat.b(),curr_lat.c());
-        s.set_lattice(compatible_lat,xtal::FRAC);
+        const auto& ref_lat = sub_strucs[0].lattice();
+        const auto& curr_lat = s.lattice();
+        xtal::Lattice compatible_lat(ref_lat.a(), ref_lat.b(), curr_lat.c());
+        s.set_lattice(compatible_lat, xtal::FRAC);
     }
 
     // Create a new lattice that has the same ab vectors. but summed up
@@ -67,13 +67,13 @@ xtal::Structure stack(std::vector<xtal::Structure> sub_strucs)
     for (int i = 1; i < sub_strucs.size(); i++)
     {
         // determine appropriate c-axis shift for position in stacking
-        c_shift += sub_strucs[i-1].lattice().column_vector_matrix().col(2);
+        c_shift += sub_strucs[i - 1].lattice().column_vector_matrix().col(2);
 
         // Shift each site of the basis by the appropriate c shift,
         // and adds them to the stacked structure
         for (const xtal::Site& s : sub_strucs[i].basis_sites())
         {
-            xtal::Coordinate new_coord = xtal::Coordinate(s.cart() + c_shift);
+            auto new_coord = s.cart() + c_shift;
             stacked_basis.emplace_back(new_coord, s.label());
         }
     }
@@ -85,7 +85,7 @@ std::vector<xtal::Site> translate_basis(const std::vector<xtal::Site>& basis, co
     std::vector<xtal::Site> translated_basis;
     for (const auto& site : basis)
     {
-        translated_basis.emplace_back(xtal::Coordinate(site.cart() + shift), site.label());
+        translated_basis.emplace_back((site.cart() + shift), site.label());
     }
 
     return translated_basis;
@@ -96,7 +96,7 @@ xtal::Structure translate_basis(const xtal::Structure& struc, const Eigen::Vecto
     std::vector<xtal::Site> translated_basis;
     for (const auto& s : struc.basis_sites())
     {
-        translated_basis.emplace_back(xtal::Coordinate(s.cart() + shift), s.label());
+        translated_basis.emplace_back((s.cart() + shift), s.label());
     }
 
     return xtal::Structure(struc.lattice(), translated_basis);

--- a/lib/casmutils/xtal/lattice.cxx
+++ b/lib/casmutils/xtal/lattice.cxx
@@ -165,22 +165,5 @@ Lattice make_superlattice(const Lattice& tiling_unit, const Eigen::Matrix3i col_
 {
     return Lattice(CASM::xtal::make_superlattice(tiling_unit.__get(), col_transf_mat));
 }
-
-Eigen::Vector3d make_fractional(const Eigen::Vector3d& cart_coord, const xtal::Lattice& lat)
-{
-    return Coordinate::from_fractional(cart_coord, lat).cart();
-}
-
-Eigen::Vector3d bring_within(const Eigen::Vector3d cart_coord, const xtal::Lattice& unit_cell)
-{
-    const xtal::Coordinate casted_cart(cart_coord);
-    return casted_cart.bring_within(unit_cell).cart();
-}
-
-Eigen::Vector3d bring_within_wigner_seitz(const Eigen::Vector3d cart_coord, const xtal::Lattice& unit_cell)
-{
-    const xtal::Coordinate casted_cart(cart_coord);
-    return casted_cart.bring_within_wigner_seitz(unit_cell).cart();
-}
 } // namespace xtal
 } // namespace casmutils

--- a/lib/casmutils/xtal/rocksalttoggler.cxx
+++ b/lib/casmutils/xtal/rocksalttoggler.cxx
@@ -273,22 +273,23 @@ void RockSaltOctahedraToggler::commit_vertex_ions() const
 
 RockSaltOctahedraToggler::index RockSaltOctahedraToggler::coordinate_to_index(Coordinate coordinate) const
 {
+    throw except::NotImplemented();
     // TODO: Bring the coordinate within relative to the rocksalt structure lattice before making any comparisons
-    coordinate.bring_within(this->rocksalt_struc.lattice());
-    // Go through the basis of the structure
-    // and find out which basis index the
-    // given coordinate corresponds to
-    auto basis = this->rocksalt_struc.basis_sites();
-    for (int ix = 0; ix < basis.size(); ++ix)
-    {
-        if (casmutils::is_equal<casmutils::xtal::CoordinateEquals_f>(
-                static_cast<Coordinate>(basis[ix]), coordinate, 1e-5))
-        {
-            return ix;
-        }
-    }
-
-    throw except::IncompatibleCoordinate();
+    //    coordinate.bring_within(this->rocksalt_struc.lattice());
+    //    // Go through the basis of the structure
+    //    // and find out which basis index the
+    //    // given coordinate corresponds to
+    //    auto basis = this->rocksalt_struc.basis_sites();
+    //    for (int ix = 0; ix < basis.size(); ++ix)
+    //    {
+    //        if (casmutils::is_equal<casmutils::xtal::CoordinateEquals_f>(
+    //                static_cast<Coordinate>(basis[ix]), coordinate, 1e-5))
+    //        {
+    //            return ix;
+    //        }
+    //    }
+    //
+    //    throw except::IncompatibleCoordinate();
 }
 
 RockSaltOctahedraToggler::Coordinate RockSaltOctahedraToggler::index_to_coordinate(index coordinate_index) const

--- a/lib/casmutils/xtal/site.cxx
+++ b/lib/casmutils/xtal/site.cxx
@@ -13,20 +13,13 @@ namespace casmutils
 namespace xtal
 {
 
-Site::operator Coordinate() const { return Coordinate(this->casm_site); }
-
-Site::Site(const Coordinate& init_coord, const std::string& occupant_name)
-    : casm_site(CASM::xtal::Site(init_coord.__get(), occupant_name))
+Site::Site(const Eigen::Vector3d& init_coord, const std::string& occupant_name)
+    : casm_site(CASM::xtal::Site(CASM::xtal::Coordinate(init_coord, CASM::xtal::Lattice(), CASM::CART), occupant_name))
 {
     // Avoid a multioccupant site
     assert(casm_site.allowed_occupants().size() == 1);
     // Avoid an unitialized state.
     this->casm_site.set_label(0);
-}
-
-Site::Site(const Eigen::Vector3d& init_coord, const std::string& occupant_name)
-    : Site(Coordinate(init_coord), occupant_name)
-{
 }
 
 Site::Site(const CASM::xtal::Site& init_site, int occupant) : casm_site(init_site)
@@ -46,8 +39,7 @@ Eigen::Vector3d Site::frac(const Lattice& ref_lattice) const
 SiteEquals_f::SiteEquals_f(const Site& ref_site, double tol) : ref_site(ref_site), tol(tol) {}
 bool SiteEquals_f::operator()(const Site& other)
 {
-    return is_equal<CoordinateEquals_f>(static_cast<Coordinate>(ref_site), static_cast<Coordinate>(other), tol) &&
-           ref_site.label() == other.label();
+    return is_equal<CoordinateEquals_f>(ref_site.cart(), other.cart(), tol) && ref_site.label() == other.label();
 }
 
 } // namespace xtal

--- a/lib/casmutils/xtal/structure.cxx
+++ b/lib/casmutils/xtal/structure.cxx
@@ -152,7 +152,7 @@ void Structure::_update_internals_from_simple()
         const auto& info =
             this->__get<CASM::xtal::SimpleStructure>().info(CASM::xtal::SimpleStructure::SpeciesMode::ATOM);
         Eigen::Vector3d raw_coord = info.cart_coord(index);
-        new_basis.emplace_back(casmutils::xtal::Coordinate(raw_coord), info.names[index]);
+        new_basis.emplace_back(raw_coord, info.names[index]);
     }
     this->basis = new_basis;
 }

--- a/lib/casmutils/xtal/symmetry.cxx
+++ b/lib/casmutils/xtal/symmetry.cxx
@@ -41,10 +41,5 @@ Eigen::Vector3d operator*(const sym::CartOp& sym_op, const Eigen::Vector3d& vect
 
 Site operator*(const sym::CartOp& sym_op, const Site& site) { return Site{sym_op * site.cart(), site.label()}; }
 
-Coordinate operator*(const sym::CartOp& sym_op, const Coordinate& coordinate)
-{
-    return Coordinate{sym_op * coordinate.cart()};
-}
-
 } // namespace xtal
 } // namespace casmutils

--- a/tests/py/casmutils/xtal/coordinate.py.in
+++ b/tests/py/casmutils/xtal/coordinate.py.in
@@ -79,6 +79,24 @@ class CoordinateTest(unittest.TestCase):
         self.coord0m += self.coord1m
         self.assertTrue(sum_coord == self.coord0m)
 
+    def test_cart_to_frac(self):
+        new_frac = cu.xtal.coordinate.cartesian_to_fractional(
+            self.raw_coord0, self.lat)
+        self.assertTrue(np.allclose(self.frac_coords0, new_frac))
+
+    def test_frac_to_cart(self):
+        new_cart = cu.xtal.coordinate.fractional_to_cartesian(
+            self.frac_coords0, self.lat)
+        self.assertTrue(np.allclose(self.raw_coord0, new_cart))
+
+    def test_within_lat(self):
+        lat_trans = cu.xtal.coordinate.fractional_to_cartesian(
+            np.array([2, 3, 4]), self.lat)
+        new_coord = np.add(self.raw_coord0, lat_trans)
+        new_within = cu.xtal.coordinate.bring_within_lattice(
+            new_coord, self.lat)
+        self.assertTrue(np.allclose(self.raw_coord0, new_within))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/casmutils/mush/shift.cpp
+++ b/tests/unit/casmutils/mush/shift.cpp
@@ -137,14 +137,14 @@ TEST_F(ShiftingTest, WignerSeitzShiftMatches)
     int didnt_match = 0;
     for (int i = 0; i < shift_values.size(); ++i)
     {
-        cu::xtal::Coordinate ws_shift(wigner_seitz_shift_values[i]);
-        if (!shift_values[i].isApprox(ws_shift.cart()))
+        auto ws_shift = wigner_seitz_shift_values[i];
+        if (!shift_values[i].isApprox(ws_shift))
         {
             ++didnt_match;
         }
 
-        ws_shift.bring_within(b2_ptr->lattice());
-        EXPECT_TRUE(shift_values[i].isApprox(ws_shift.cart()));
+        ws_shift = cu::xtal::coordinate::bring_within_lattice(ws_shift, b2_ptr->lattice());
+        EXPECT_TRUE(shift_values[i].isApprox(ws_shift));
     }
 
     EXPECT_TRUE(didnt_match >= as * bs / 4);

--- a/tests/unit/casmutils/mush/slab.cpp
+++ b/tests/unit/casmutils/mush/slab.cpp
@@ -100,8 +100,12 @@ TEST_F(SlicingTest, StructureSlice_b2_101)
 
     EXPECT_EQ(b2_slice.basis_sites().size(), 4);
 
-    cu::xtal::Site site0(cu::xtal::Coordinate::from_fractional(0, 0, 0, b2_slice.lattice()), "A");
-    cu::xtal::Site site1(cu::xtal::Coordinate::from_fractional(0.5, 0.5, 0, b2_slice.lattice()), "B");
+    cu::xtal::Site site0(
+        cu::xtal::coordinate::get_cartesian_coordinates_from_fractional(Eigen::Vector3d(0, 0, 0), b2_slice.lattice()),
+        "A");
+    cu::xtal::Site site1(cu::xtal::coordinate::get_cartesian_coordinates_from_fractional(Eigen::Vector3d(0.5, 0.5, 0),
+                                                                                         b2_slice.lattice()),
+                         "B");
 
     cu::xtal::SiteEquals_f is_equal_site0(site0, tol);
     EXPECT_TRUE(std::find_if(b2_slice.basis_sites().begin(), b2_slice.basis_sites().end(), is_equal_site0) !=

--- a/tests/unit/casmutils/mush/slab.cpp
+++ b/tests/unit/casmutils/mush/slab.cpp
@@ -101,9 +101,9 @@ TEST_F(SlicingTest, StructureSlice_b2_101)
     EXPECT_EQ(b2_slice.basis_sites().size(), 4);
 
     cu::xtal::Site site0(
-        cu::xtal::coordinate::get_cartesian_coordinates_from_fractional(Eigen::Vector3d(0, 0, 0), b2_slice.lattice()),
+        cu::xtal::coordinate::fractional_to_cartesian(Eigen::Vector3d(0, 0, 0), b2_slice.lattice()),
         "A");
-    cu::xtal::Site site1(cu::xtal::coordinate::get_cartesian_coordinates_from_fractional(Eigen::Vector3d(0.5, 0.5, 0),
+    cu::xtal::Site site1(cu::xtal::coordinate::fractional_to_cartesian(Eigen::Vector3d(0.5, 0.5, 0),
                                                                                          b2_slice.lattice()),
                          "B");
 

--- a/tests/unit/casmutils/xtal/coordinate.cpp
+++ b/tests/unit/casmutils/xtal/coordinate.cpp
@@ -8,38 +8,36 @@
 class CoordinateTest : public testing::Test
 {
 protected:
-    using Coordinate = casmutils::xtal::Coordinate;
     using Lattice = casmutils::xtal::Lattice;
     using CoordinateEquals_f = casmutils::xtal::CoordinateEquals_f;
     // Use unique pointers because Coordinate has no default constructor
-    std::unique_ptr<Coordinate> coord0_ptr;
-    std::unique_ptr<Coordinate> coord1_ptr;
+    Eigen::Vector3d coord0;
     std::unique_ptr<Lattice> fcc_lattice_ptr;
-    std::unique_ptr<Coordinate> coord2_ptr;
     Eigen::Matrix3d lattice_matrix;
     Eigen::Vector3d frac_coords;
     double tol = 1e-5;
 
     void SetUp() override
     {
-
-        Eigen::Vector3d raw_coord(0.1, 0.2, 0.3);
+        coord0 << 0.1, 0.2, 0.3;
         lattice_matrix << 0, 0.5, 0.5, 0.5, 0, 0.5, 0.5, 0.5, 0;
-        coord0_ptr.reset(new Coordinate(raw_coord));
-        coord1_ptr.reset(new Coordinate(raw_coord(0), raw_coord(1), raw_coord(2)));
         fcc_lattice_ptr.reset(new Lattice(lattice_matrix));
-        frac_coords = lattice_matrix.inverse() * coord0_ptr->cart();
-        coord2_ptr.reset(new Coordinate(Coordinate::from_fractional(frac_coords, *fcc_lattice_ptr)));
+        frac_coords = lattice_matrix.inverse() * coord0;
     }
 };
 
-TEST_F(CoordinateTest, Construct)
+TEST_F(CoordinateTest, CartRetrieve)
 {
-    EXPECT_TRUE(casmutils::is_equal<CoordinateEquals_f>(*coord0_ptr, *coord1_ptr, tol));
-    EXPECT_TRUE(casmutils::is_equal<CoordinateEquals_f>(*coord1_ptr, *coord2_ptr, tol));
+    Eigen::Vector3d new_cart_coords =
+        casmutils::xtal::coordinate::get_cartesian_coordinates_from_fractional(frac_coords, *fcc_lattice_ptr);
+    EXPECT_TRUE(coord0.isApprox(new_cart_coords, tol));
 }
 
-TEST_F(CoordinateTest, FracRetrieve) { EXPECT_TRUE(frac_coords.isApprox(coord2_ptr->frac(*fcc_lattice_ptr))); }
+TEST_F(CoordinateTest, FracRetrieve)
+{
+    Eigen::Vector3d new_frac_coords = casmutils::xtal::coordinate::get_fractional_coordinates(coord0, *fcc_lattice_ptr);
+    EXPECT_TRUE(frac_coords.isApprox(new_frac_coords, tol));
+}
 
 TEST_F(CoordinateTest, BringWithIn)
 {
@@ -50,81 +48,47 @@ TEST_F(CoordinateTest, BringWithIn)
         {
             for (int l = 2; l <= 2; ++l)
             {
-                Coordinate lattice_translation = Coordinate::from_fractional(i, j, l, *fcc_lattice_ptr);
-                Coordinate translated_coordinate = *coord0_ptr + lattice_translation;
-                translated_coordinate.bring_within(*fcc_lattice_ptr);
-                EXPECT_TRUE(casmutils::is_equal<CoordinateEquals_f>(*coord0_ptr, translated_coordinate, tol));
+                Eigen::Vector3d lattice_translation =
+                    casmutils::xtal::coordinate::get_cartesian_coordinates_from_fractional(Eigen::Vector3d(i, j, l),
+                                                                                           *fcc_lattice_ptr);
+                Eigen::Vector3d translated_coordinate = coord0 + lattice_translation;
+                Eigen::Vector3d withined_coords =
+                    casmutils::xtal::coordinate::bring_within_lattice(translated_coordinate, *fcc_lattice_ptr);
+                EXPECT_TRUE(coord0.isApprox(withined_coords));
             }
         }
     }
-}
-
-TEST_F(CoordinateTest, ConstBringWithIn)
-{
-    Coordinate lattice_translation = Coordinate::from_fractional(2, 3, 4, *fcc_lattice_ptr);
-    const Coordinate translated_coordinate = *coord0_ptr + lattice_translation;
-    Coordinate original_coord = translated_coordinate.bring_within(*fcc_lattice_ptr);
-
-    EXPECT_FALSE(casmutils::is_equal<CoordinateEquals_f>(translated_coordinate, original_coord, tol));
-    EXPECT_TRUE(casmutils::is_equal<CoordinateEquals_f>(*coord0_ptr, original_coord, tol));
 }
 
 TEST_F(CoordinateTest, WignerSeitzWithin)
 {
-    Coordinate already_within = Coordinate::from_fractional(0.25, 0.25, 0, *fcc_lattice_ptr);
-    Coordinate ws_within = Coordinate::from_fractional(0.25, 0.25, 0, *fcc_lattice_ptr);
+    auto already_within = casmutils::xtal::coordinate::get_cartesian_coordinates_from_fractional(
+        Eigen::Vector3d(0.25, 0.25, 0), *fcc_lattice_ptr);
+    auto ws_within = casmutils::xtal::coordinate::get_cartesian_coordinates_from_fractional(
+        Eigen::Vector3d(0.25, 0.25, 0), *fcc_lattice_ptr);
 
-    already_within.bring_within_wigner_seitz(*fcc_lattice_ptr);
-    EXPECT_TRUE(casmutils::is_equal<CoordinateEquals_f>(already_within, ws_within, tol));
+    auto new_within = casmutils::xtal::coordinate::bring_within_wigner_seitz(already_within, *fcc_lattice_ptr);
+    EXPECT_TRUE(casmutils::is_equal<CoordinateEquals_f>(new_within, ws_within, tol));
 
-    Coordinate far_right = Coordinate::from_fractional(0.75, 0.25, 0, *fcc_lattice_ptr);
-    Coordinate far_far_right = Coordinate::from_fractional(1.75, 0.25, 0, *fcc_lattice_ptr);
-    ws_within = Coordinate::from_fractional(-0.25, 0.25, 0, *fcc_lattice_ptr);
+    auto far_right = casmutils::xtal::coordinate::get_cartesian_coordinates_from_fractional(
+        Eigen::Vector3d(0.75, 0.25, 0), *fcc_lattice_ptr);
+    auto far_far_right = casmutils::xtal::coordinate::get_cartesian_coordinates_from_fractional(
+        Eigen::Vector3d(1.75, 0.25, 0), *fcc_lattice_ptr);
+    ws_within = casmutils::xtal::coordinate::get_cartesian_coordinates_from_fractional(Eigen::Vector3d(-0.25, 0.25, 0),
+                                                                                       *fcc_lattice_ptr);
 
-    far_right.bring_within_wigner_seitz(*fcc_lattice_ptr);
-    EXPECT_TRUE(casmutils::is_equal<CoordinateEquals_f>(far_right, ws_within, tol));
-    far_far_right.bring_within_wigner_seitz(*fcc_lattice_ptr);
-    EXPECT_TRUE(casmutils::is_equal<CoordinateEquals_f>(far_far_right, ws_within, tol));
-}
+    auto new_far_right = casmutils::xtal::coordinate::bring_within_wigner_seitz(far_right, *fcc_lattice_ptr);
+    EXPECT_TRUE(casmutils::is_equal<CoordinateEquals_f>(new_far_right, ws_within, tol));
 
-TEST_F(CoordinateTest, ConstWignerSeitzWithin)
-{
-    for (double x : {-0.1, 0.7, -2.2, 0.0})
-    {
-        for (double y : {-0.1, 0.7, -2.2, 0.0})
-        {
-            for (double z : {-0.1, 0.7, -2.2, 0.0})
-            {
-                const Coordinate const_coord = Coordinate::from_fractional(x, y, z, *fcc_lattice_ptr);
-                Coordinate coord = const_coord;
-
-                coord.bring_within_wigner_seitz(*fcc_lattice_ptr);
-                EXPECT_TRUE(casmutils::is_equal<CoordinateEquals_f>(
-                    const_coord.bring_within_wigner_seitz(*fcc_lattice_ptr), coord, tol));
-            }
-        }
-    }
-}
-
-TEST_F(CoordinateTest, PlusOperator)
-{
-    Coordinate coord_sum = *coord0_ptr + *coord1_ptr;
-    Coordinate summed_coord(coord0_ptr->cart() + coord1_ptr->cart());
-    EXPECT_TRUE(casmutils::is_equal<CoordinateEquals_f>(coord_sum, summed_coord, tol));
-}
-
-TEST_F(CoordinateTest, PlusEqualOperator)
-{
-    Eigen::Vector3d sum_cart(0.2, 0.4, 0.6);
-    Coordinate sum_coord(sum_cart);
-    *coord0_ptr += *coord1_ptr;
-    EXPECT_TRUE(casmutils::is_equal<CoordinateEquals_f>(*coord0_ptr, sum_coord, tol));
+    auto new_far_far_right = casmutils::xtal::coordinate::bring_within_wigner_seitz(far_far_right, *fcc_lattice_ptr);
+    EXPECT_TRUE(casmutils::is_equal<CoordinateEquals_f>(new_far_far_right, ws_within, tol));
 }
 
 TEST_F(CoordinateTest, CoordinateEquals)
 {
-    CoordinateEquals_f coord0_equals(*coord0_ptr, tol);
-    EXPECT_TRUE(coord0_equals(*coord1_ptr));
+    auto coord1 = coord0;
+    CoordinateEquals_f coord0_equals(coord0, tol);
+    EXPECT_TRUE(coord0_equals(coord1));
 }
 
 //

--- a/tests/unit/casmutils/xtal/coordinate.cpp
+++ b/tests/unit/casmutils/xtal/coordinate.cpp
@@ -29,13 +29,13 @@ protected:
 TEST_F(CoordinateTest, CartRetrieve)
 {
     Eigen::Vector3d new_cart_coords =
-        casmutils::xtal::coordinate::get_cartesian_coordinates_from_fractional(frac_coords, *fcc_lattice_ptr);
+        casmutils::xtal::coordinate::fractional_to_cartesian(frac_coords, *fcc_lattice_ptr);
     EXPECT_TRUE(coord0.isApprox(new_cart_coords, tol));
 }
 
 TEST_F(CoordinateTest, FracRetrieve)
 {
-    Eigen::Vector3d new_frac_coords = casmutils::xtal::coordinate::get_fractional_coordinates(coord0, *fcc_lattice_ptr);
+    Eigen::Vector3d new_frac_coords = casmutils::xtal::coordinate::cartesian_to_fractional(coord0, *fcc_lattice_ptr);
     EXPECT_TRUE(frac_coords.isApprox(new_frac_coords, tol));
 }
 
@@ -49,7 +49,7 @@ TEST_F(CoordinateTest, BringWithIn)
             for (int l = 2; l <= 2; ++l)
             {
                 Eigen::Vector3d lattice_translation =
-                    casmutils::xtal::coordinate::get_cartesian_coordinates_from_fractional(Eigen::Vector3d(i, j, l),
+                    casmutils::xtal::coordinate::fractional_to_cartesian(Eigen::Vector3d(i, j, l),
                                                                                            *fcc_lattice_ptr);
                 Eigen::Vector3d translated_coordinate = coord0 + lattice_translation;
                 Eigen::Vector3d withined_coords =
@@ -62,19 +62,19 @@ TEST_F(CoordinateTest, BringWithIn)
 
 TEST_F(CoordinateTest, WignerSeitzWithin)
 {
-    auto already_within = casmutils::xtal::coordinate::get_cartesian_coordinates_from_fractional(
+    auto already_within = casmutils::xtal::coordinate::fractional_to_cartesian(
         Eigen::Vector3d(0.25, 0.25, 0), *fcc_lattice_ptr);
-    auto ws_within = casmutils::xtal::coordinate::get_cartesian_coordinates_from_fractional(
+    auto ws_within = casmutils::xtal::coordinate::fractional_to_cartesian(
         Eigen::Vector3d(0.25, 0.25, 0), *fcc_lattice_ptr);
 
     auto new_within = casmutils::xtal::coordinate::bring_within_wigner_seitz(already_within, *fcc_lattice_ptr);
     EXPECT_TRUE(casmutils::is_equal<CoordinateEquals_f>(new_within, ws_within, tol));
 
-    auto far_right = casmutils::xtal::coordinate::get_cartesian_coordinates_from_fractional(
+    auto far_right = casmutils::xtal::coordinate::fractional_to_cartesian(
         Eigen::Vector3d(0.75, 0.25, 0), *fcc_lattice_ptr);
-    auto far_far_right = casmutils::xtal::coordinate::get_cartesian_coordinates_from_fractional(
+    auto far_far_right = casmutils::xtal::coordinate::fractional_to_cartesian(
         Eigen::Vector3d(1.75, 0.25, 0), *fcc_lattice_ptr);
-    ws_within = casmutils::xtal::coordinate::get_cartesian_coordinates_from_fractional(Eigen::Vector3d(-0.25, 0.25, 0),
+    ws_within = casmutils::xtal::coordinate::fractional_to_cartesian(Eigen::Vector3d(-0.25, 0.25, 0),
                                                                                        *fcc_lattice_ptr);
 
     auto new_far_right = casmutils::xtal::coordinate::bring_within_wigner_seitz(far_right, *fcc_lattice_ptr);

--- a/tests/unit/casmutils/xtal/site.cpp
+++ b/tests/unit/casmutils/xtal/site.cpp
@@ -12,24 +12,19 @@ protected:
     void SetUp() override
     {
         Eigen::Vector3d raw_coord(0.1, 0.2, 0.3);
-        Coordinate init_position(raw_coord);
         // store coordinate object for comparisons later
-        init_pos_ptr.reset(new Coordinate(raw_coord));
         // Makes lithium and nickel sites with the same position
-        lithium_site_ptr.reset(new Site(init_position, "Li"));
-        nickel_site_ptr.reset(new Site(init_position, "Ni"));
+        lithium_site_ptr.reset(new Site(raw_coord, "Li"));
+        nickel_site_ptr.reset(new Site(raw_coord, "Ni"));
         // store lattice for coordinate transforms
         cubic_lattice_ptr.reset(new Lattice(4.0 * Eigen::Matrix3d::Identity()));
     }
-    using Coordinate = casmutils::xtal::Coordinate;
     using Lattice = casmutils::xtal::Lattice;
     using Site = casmutils::xtal::Site;
 
     // Use unique pointers because Site has no default constructor
     std::unique_ptr<Site> lithium_site_ptr;
     std::unique_ptr<Site> nickel_site_ptr;
-
-    std::unique_ptr<Coordinate> init_pos_ptr;
 
     std::unique_ptr<Lattice> cubic_lattice_ptr;
 };
@@ -43,12 +38,6 @@ TEST_F(SiteTest, Construct)
     EXPECT_EQ(lithium_site_ptr->label(), "Li");
     EXPECT_EQ(nickel_site_ptr->label(), "Ni");
 }
-
-TEST_F(SiteTest, CoordCast)
-{
-    // checks the ability to cast a Site to a Coordinate
-    EXPECT_EQ(Coordinate(*lithium_site_ptr).cart(), init_pos_ptr->cart());
-};
 
 TEST_F(SiteTest, FracConversion)
 {

--- a/tests/unit/casmutils/xtal/structure.cpp
+++ b/tests/unit/casmutils/xtal/structure.cpp
@@ -20,8 +20,8 @@ protected:
         cubic_lat_ptr.reset(new casmutils::xtal::Lattice(cubic_lat_mat));
         big_cubic_lat_ptr.reset(new casmutils::xtal::Lattice(2 * cubic_lat_mat));
         // Make two Ni sites at different locations along z axis
-        casmutils::xtal::Site site0(casmutils::xtal::Coordinate(Eigen::Vector3d(0, 0, 1)), "Ni");
-        casmutils::xtal::Site site1(casmutils::xtal::Coordinate(Eigen::Vector3d(0, 0, 2)), "Ni");
+        casmutils::xtal::Site site0(Eigen::Vector3d(0, 0, 1), "Ni");
+        casmutils::xtal::Site site1(Eigen::Vector3d(0, 0, 2), "Ni");
         // Make bases out of each site
         basis0_ptr.reset(new std::vector<casmutils::xtal::Site>({site0}));
         basis1_ptr.reset(new std::vector<casmutils::xtal::Site>({site1}));
@@ -98,7 +98,7 @@ TEST_F(StructureTest, ConstSetLatticeCart)
 TEST_F(StructureTest, Within)
 {
     // checks to see if all basis sites can be moved within the bounding box of the lattice
-    casmutils::xtal::Site outside_site(casmutils::xtal::Coordinate(0, 0, -1), "Ni");
+    casmutils::xtal::Site outside_site(Eigen::Vector3d(0, 0, -1), "Ni");
     casmutils::xtal::Structure outside_structure(*cubic_lat_ptr, {outside_site});
     outside_structure.within();
     EXPECT_TRUE(

--- a/tests/unit/casmutils/xtal/symmetry.cpp
+++ b/tests/unit/casmutils/xtal/symmetry.cpp
@@ -31,7 +31,6 @@ protected:
     using Lattice = cu::xtal::Lattice;
     using Structure = cu::xtal::Structure;
     using CartOp = cu::sym::CartOp;
-    using Coordinate = cu::xtal::Coordinate;
     void SetUp() override
     {
         Eigen::Matrix3d cubic_lat_matrix = 3 * Eigen::Matrix3d::Identity();
@@ -50,7 +49,6 @@ protected:
         translation << 0.5, 0.5, 0.5;
         eigen_vector_coordinate << 1.2, 1.3, 1.4;
         cart_op_ptr.reset(new CartOp{rotation_90, translation, false});
-        coord_ptr.reset(new Coordinate{eigen_vector_coordinate});
     }
 
     std::unique_ptr<Lattice> cubic_lat_ptr;
@@ -58,7 +56,6 @@ protected:
     std::unique_ptr<Structure> hcp_Mg_ptr;
     std::unique_ptr<Structure> almost_hcp_Mg_ptr;
     std::unique_ptr<CartOp> cart_op_ptr;
-    std::unique_ptr<Coordinate> coord_ptr;
     Eigen::Matrix3d rotation_90;
     Eigen::Vector3d translation;
     Eigen::Vector3d eigen_vector_coordinate;
@@ -104,17 +101,10 @@ TEST_F(SymmetrizeTest, ApplySymOpEigenVector)
 
 TEST_F(SymmetrizeTest, ApplySymOpSite)
 {
-    cu::xtal::Site lithium_site(*coord_ptr, "Li");
+    cu::xtal::Site lithium_site(eigen_vector_coordinate, "Li");
     auto transformed_site = *cart_op_ptr * lithium_site;
     EXPECT_TRUE(transformed_site.cart().isApprox(rotation_90 * lithium_site.cart() + translation));
     EXPECT_EQ(transformed_site.label(), lithium_site.label());
-}
-
-TEST_F(SymmetrizeTest, ApplySymOpCoordinate)
-{
-    auto coord = *coord_ptr;
-    auto transformed_coord = *cart_op_ptr * coord;
-    EXPECT_TRUE(transformed_coord.cart().isApprox(rotation_90 * coord_ptr->cart() + translation));
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
- Nuked Coordinate class out of existence in cpp
- Instead there are 4 functions now in the newly introduced `coordinate` namespace in `casmutils::xtal`
- The 4 functions are `cartesian_to_fractional`, `fractional_to_cartesian`, `bring_within_lattice`,  `bring_within_wigner_seitz`.
- Please suggest any other useful functions if I've missed them @goirijo , @jonaskaufman , @skk74 
- Removed `Coordinate` class dependencies from every other module
- Readjusted the `Coordinate` class in python to take into account the changes made in the cpp part. I believe that `Coordinate` class in python is a bit useful (be it *,  +, += operators not available for numpy arrays or the operator overloading that can be done by symop). What do you think @goirijo?
- And also I still have to work on comparator classes hence I haven't touched `CoordinateEquals_f` class yet. I just modified it to work now but I suppose it can be removed altogether because it is just isApprox of the vector. 