### PR TITLE
The long awaited BinaryComparators are here!!!

### DIFF
--- a/include/casmutils/misc.hpp
+++ b/include/casmutils/misc.hpp
@@ -24,8 +24,8 @@ using CASM::almost_zero;
 template <typename ComparatorType_f, typename CompareType, typename... Args>
 bool is_equal(const CompareType& reference, const CompareType& other, const Args&... functor_params)
 {
-    ComparatorType_f reference_equals(reference, functor_params...);
-    return reference_equals(other);
+    ComparatorType_f reference_equals(functor_params...);
+    return reference_equals(reference, other);
 }
 
 } // namespace casmutils

--- a/include/casmutils/misc.hpp
+++ b/include/casmutils/misc.hpp
@@ -3,6 +3,7 @@
 
 #include <casm/external/Eigen/Core>
 #include <casm/misc/CASM_Eigen_math.hh>
+#include <casm/misc/type_traits.hh>
 #include <string>
 #include <vector>
 
@@ -27,6 +28,27 @@ bool is_equal(const CompareType& reference, const CompareType& other, const Args
     ComparatorType_f reference_equals(functor_params...);
     return reference_equals(reference, other);
 }
+
+/// Use this class to convert a BinaryComparator_f functor to UnaryComparator_f functor useful in std::find_if
+/// For example if you have a "LatticeEquals_f" BinaryComparator and you want a UnaryComparator_f out of it:
+/// UnaryComparator_f<LatticeEquals_f> lattice_unary_compare(ref_lattice, tol);
+template <typename BinaryComparator_f> class UnaryComparator_f
+{
+public:
+    using CompareType = notstd::first_argument_type<BinaryComparator_f>;
+
+    template <typename... Args>
+    UnaryComparator_f(const CompareType& ref_value, const Args&... functor_params)
+        : m_ref_value(ref_value), m_compare_method(functor_params...)
+    {
+    }
+
+    bool operator()(const CompareType& other_value) { return m_compare_method(m_ref_value, other_value); }
+
+private:
+    CompareType m_ref_value;
+    BinaryComparator_f m_compare_method;
+};
 
 } // namespace casmutils
 

--- a/include/casmutils/xtal/coordinate.hpp
+++ b/include/casmutils/xtal/coordinate.hpp
@@ -70,12 +70,11 @@ struct CoordinateEquals_f
     /// for casmutils::xtal::Coordinate
 public:
     /// Determines whether test is equal to reference site with a tolerance
-    CoordinateEquals_f(const Coordinate& ref_coordinate, double tol);
+    CoordinateEquals_f(double tol);
     /// Returns true if other is equal to the Coordinate the comparator was constructed with
-    bool operator()(const Coordinate& other);
+    bool operator()(const Coordinate& ref_coordinate, const Coordinate& other);
 
 private:
-    Coordinate ref_coordinate;
     double tol;
 };
 

--- a/include/casmutils/xtal/coordinate.hpp
+++ b/include/casmutils/xtal/coordinate.hpp
@@ -72,7 +72,7 @@ public:
     /// Determines whether test is equal to reference site with a tolerance
     CoordinateEquals_f(double tol);
     /// Returns true if other is equal to the Coordinate the comparator was constructed with
-    bool operator()(const Coordinate& ref_coordinate, const Coordinate& other);
+    bool operator()(const Coordinate& ref_coordinate, const Coordinate& other) const;
 
 private:
     double tol;

--- a/include/casmutils/xtal/lattice.hpp
+++ b/include/casmutils/xtal/lattice.hpp
@@ -18,7 +18,6 @@ public:
     /// Construct lattice by specifying each individual vector
     Lattice(const Eigen::Vector3d& a, const Eigen::Vector3d& b, const Eigen::Vector3d& c);
 
-
     static Lattice from_column_vector_matrix(const Eigen::Matrix3d& column_vector_matrix)
     {
         return Lattice(column_vector_matrix);
@@ -43,7 +42,6 @@ public:
                                            const double& alpha,
                                            const double& beta,
                                            const double& gamma);
-
 
     // TODO: Read up on Eigen::Matrix3d::ColXpr and decide if you prefer this. CASM does it this way.
     /// Return the ith vector of the lattice
@@ -84,12 +82,11 @@ class LatticeEquals_f
 {
 public:
     /// The comparator requires a tolerance
-    LatticeEquals_f(const Lattice& ref_lat, double tol);
+    LatticeEquals_f(double tol);
     /// returns true is ref_lat is equal to other by direct vector comparison
-    bool operator()(const Lattice& other);
+    bool operator()(const Lattice& ref_lat, const Lattice& other);
 
 private:
-    Lattice ref_lat;
     double tol;
 };
 

--- a/include/casmutils/xtal/lattice.hpp
+++ b/include/casmutils/xtal/lattice.hpp
@@ -84,7 +84,7 @@ public:
     /// The comparator requires a tolerance
     LatticeEquals_f(double tol);
     /// returns true is ref_lat is equal to other by direct vector comparison
-    bool operator()(const Lattice& ref_lat, const Lattice& other);
+    bool operator()(const Lattice& ref_lat, const Lattice& other) const;
 
 private:
     double tol;

--- a/include/casmutils/xtal/site.hpp
+++ b/include/casmutils/xtal/site.hpp
@@ -51,7 +51,7 @@ public:
     /// Determines whether test is equal to reference site with a tolerance
     SiteEquals_f(double tol);
     /// Returns true if other is equal to ref_site
-    bool operator()(const Site& ref_site, const Site& other);
+    bool operator()(const Site& ref_site, const Site& other) const;
 
 private:
     double tol;

--- a/include/casmutils/xtal/site.hpp
+++ b/include/casmutils/xtal/site.hpp
@@ -49,12 +49,11 @@ class SiteEquals_f
 {
 public:
     /// Determines whether test is equal to reference site with a tolerance
-    SiteEquals_f(const Site& ref_site, double tol);
+    SiteEquals_f(double tol);
     /// Returns true if other is equal to ref_site
-    bool operator()(const Site& other);
+    bool operator()(const Site& ref_site, const Site& other);
 
 private:
-    Site ref_site;
     double tol;
 };
 } // namespace xtal

--- a/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
+++ b/lib-py/casmutils/xtal/_xtal/xtal-py.cxx
@@ -64,7 +64,7 @@ PYBIND11_MODULE(_xtal, m)
 
     {
         class_<xtal::LatticeEquals_f>(m, "LatticeEquals_f")
-            .def(init<xtal::Lattice, double>())
+            .def(init<double>())
             .def("__call__", &xtal::LatticeEquals_f::operator());
     }
 
@@ -90,7 +90,7 @@ PYBIND11_MODULE(_xtal, m)
 
     {
         class_<xtal::CoordinateEquals_f>(m, "CoordinateEquals_f")
-            .def(init<xtal::Coordinate, double>())
+            .def(init<double>())
             .def("__call__", &xtal::CoordinateEquals_f::operator());
     }
 
@@ -110,7 +110,7 @@ PYBIND11_MODULE(_xtal, m)
 
     {
         class_<xtal::SiteEquals_f>(m, "SiteEquals_f")
-            .def(init<xtal::Site, double>())
+            .def(init<double>())
             .def("__call__", &xtal::SiteEquals_f::operator());
     }
 

--- a/lib-py/casmutils/xtal/coordinate.py
+++ b/lib-py/casmutils/xtal/coordinate.py
@@ -17,8 +17,8 @@ class Equals:
         tol : double
 
         """
-        self._CoordinateEquals_f = _xtal.CoordinateEquals_f(
-            ref_coordinate._pybind_value, tol)
+        self.ref_coordinate = ref_coordinate
+        self._CoordinateEquals_f = _xtal.CoordinateEquals_f(tol)
 
     def __call__(self, other):
         """
@@ -31,7 +31,8 @@ class Equals:
         bool
 
         """
-        return self._CoordinateEquals_f(other._pybind_value)
+        return self._CoordinateEquals_f(self.ref_coordinate._pybind_value,
+                                        other._pybind_value)
 
 
 class _Coordinate:

--- a/lib-py/casmutils/xtal/lattice.py
+++ b/lib-py/casmutils/xtal/lattice.py
@@ -17,7 +17,8 @@ class Equals:
         tol : double
 
         """
-        self._LatticeEquals_f = _xtal.LatticeEquals_f(ref_lattice, tol)
+        self.ref_lattice = ref_lattice
+        self._LatticeEquals_f = _xtal.LatticeEquals_f(tol)
 
     def __call__(self, other):
         """
@@ -30,7 +31,7 @@ class Equals:
         bool
 
         """
-        return self._LatticeEquals_f(other)
+        return self._LatticeEquals_f(self.ref_lattice, other)
 
 
 class Lattice(_xtal.Lattice):

--- a/lib-py/casmutils/xtal/site.py
+++ b/lib-py/casmutils/xtal/site.py
@@ -16,7 +16,8 @@ class Equals:
         tol : double
 
         """
-        self._SiteEquals_f = _xtal.SiteEquals_f(ref_site._pybind_value, tol)
+        self.ref_site = ref_site
+        self._SiteEquals_f = _xtal.SiteEquals_f(tol)
 
     def __call__(self, other):
         """
@@ -29,7 +30,8 @@ class Equals:
         bool
 
         """
-        return self._SiteEquals_f(other._pybind_value)
+        return self._SiteEquals_f(self.ref_site._pybind_value,
+                                  other._pybind_value)
 
 
 class _Site:

--- a/lib/casmutils/xtal/coordinate.cxx
+++ b/lib/casmutils/xtal/coordinate.cxx
@@ -67,11 +67,8 @@ Coordinate Coordinate::operator+(const Coordinate& coord_to_add) const
     return summed_coord;
 }
 
-CoordinateEquals_f::CoordinateEquals_f(const Coordinate& ref_coordinate, double tol)
-    : ref_coordinate(ref_coordinate), tol(tol)
-{
-}
-bool CoordinateEquals_f::operator()(const Coordinate& other)
+CoordinateEquals_f::CoordinateEquals_f(double tol) : tol(tol) {}
+bool CoordinateEquals_f::operator()(const Coordinate& ref_coordinate, const Coordinate& other)
 {
     return ref_coordinate.cart().isApprox(other.cart(), tol);
 }

--- a/lib/casmutils/xtal/coordinate.cxx
+++ b/lib/casmutils/xtal/coordinate.cxx
@@ -68,7 +68,7 @@ Coordinate Coordinate::operator+(const Coordinate& coord_to_add) const
 }
 
 CoordinateEquals_f::CoordinateEquals_f(double tol) : tol(tol) {}
-bool CoordinateEquals_f::operator()(const Coordinate& ref_coordinate, const Coordinate& other)
+bool CoordinateEquals_f::operator()(const Coordinate& ref_coordinate, const Coordinate& other) const
 {
     return ref_coordinate.cart().isApprox(other.cart(), tol);
 }

--- a/lib/casmutils/xtal/lattice.cxx
+++ b/lib/casmutils/xtal/lattice.cxx
@@ -74,7 +74,7 @@ Lattice::stack_column_vectors(const Eigen::Vector3d& a, const Eigen::Vector3d& b
 }
 
 LatticeEquals_f::LatticeEquals_f(double tol) : tol(tol) {}
-bool LatticeEquals_f::operator()(const Lattice& ref_lat, const Lattice& other)
+bool LatticeEquals_f::operator()(const Lattice& ref_lat, const Lattice& other) const
 {
     return ref_lat.column_vector_matrix().isApprox(other.column_vector_matrix(), tol);
 }

--- a/lib/casmutils/xtal/lattice.cxx
+++ b/lib/casmutils/xtal/lattice.cxx
@@ -73,8 +73,8 @@ Lattice::stack_column_vectors(const Eigen::Vector3d& a, const Eigen::Vector3d& b
     return column_matrix;
 }
 
-LatticeEquals_f::LatticeEquals_f(const Lattice& ref_lat, double tol) : ref_lat(ref_lat), tol(tol) {}
-bool LatticeEquals_f::operator()(const Lattice& other)
+LatticeEquals_f::LatticeEquals_f(double tol) : tol(tol) {}
+bool LatticeEquals_f::operator()(const Lattice& ref_lat, const Lattice& other)
 {
     return ref_lat.column_vector_matrix().isApprox(other.column_vector_matrix(), tol);
 }

--- a/lib/casmutils/xtal/site.cxx
+++ b/lib/casmutils/xtal/site.cxx
@@ -44,7 +44,7 @@ Eigen::Vector3d Site::frac(const Lattice& ref_lattice) const
 }
 
 SiteEquals_f::SiteEquals_f(double tol) : tol(tol) {}
-bool SiteEquals_f::operator()(const Site& ref_site, const Site& other)
+bool SiteEquals_f::operator()(const Site& ref_site, const Site& other) const
 {
     return is_equal<CoordinateEquals_f>(static_cast<Coordinate>(ref_site), static_cast<Coordinate>(other), tol) &&
            ref_site.label() == other.label();

--- a/lib/casmutils/xtal/site.cxx
+++ b/lib/casmutils/xtal/site.cxx
@@ -43,8 +43,8 @@ Eigen::Vector3d Site::frac(const Lattice& ref_lattice) const
     return ref_lattice.column_vector_matrix().inverse() * this->cart();
 }
 
-SiteEquals_f::SiteEquals_f(const Site& ref_site, double tol) : ref_site(ref_site), tol(tol) {}
-bool SiteEquals_f::operator()(const Site& other)
+SiteEquals_f::SiteEquals_f(double tol) : tol(tol) {}
+bool SiteEquals_f::operator()(const Site& ref_site, const Site& other)
 {
     return is_equal<CoordinateEquals_f>(static_cast<Coordinate>(ref_site), static_cast<Coordinate>(other), tol) &&
            ref_site.label() == other.label();

--- a/tests/unit/casmutils/mush/slab.cpp
+++ b/tests/unit/casmutils/mush/slab.cpp
@@ -103,13 +103,16 @@ TEST_F(SlicingTest, StructureSlice_b2_101)
     cu::xtal::Site site0(cu::xtal::Coordinate::from_fractional(0, 0, 0, b2_slice.lattice()), "A");
     cu::xtal::Site site1(cu::xtal::Coordinate::from_fractional(0.5, 0.5, 0, b2_slice.lattice()), "B");
 
-    cu::xtal::SiteEquals_f is_equal_site0(site0, tol);
-    EXPECT_TRUE(std::find_if(b2_slice.basis_sites().begin(), b2_slice.basis_sites().end(), is_equal_site0) !=
-                b2_slice.basis_sites().end());
+    cu::xtal::SiteEquals_f is_equal_site(tol);
+    EXPECT_TRUE(
+        std::find_if(b2_slice.basis_sites().begin(), b2_slice.basis_sites().end(), [&](const cu::xtal::Site& site) {
+            return is_equal_site(site, site0);
+        }) != b2_slice.basis_sites().end());
 
-    cu::xtal::SiteEquals_f is_equal_site1(site1, tol);
-    EXPECT_TRUE(std::find_if(b2_slice.basis_sites().begin(), b2_slice.basis_sites().end(), is_equal_site1) !=
-                b2_slice.basis_sites().end());
+    EXPECT_TRUE(
+        std::find_if(b2_slice.basis_sites().begin(), b2_slice.basis_sites().end(), [&](const cu::xtal::Site& site) {
+            return is_equal_site(site, site1);
+        }) != b2_slice.basis_sites().end());
 }
 
 //******************************************************************************//
@@ -265,8 +268,8 @@ TEST_F(OrthogonalizeCVector, EquivalentToStack)
     EXPECT_TRUE(equivalent(stack, ortho));
 
     // TODO: make this a binary comparator ffs
-    cu::xtal::LatticeEquals_f equal(stack, 1e-8);
-    EXPECT_FALSE(equal(ortho));
+    cu::xtal::LatticeEquals_f equal(1e-8);
+    EXPECT_FALSE(equal(stack, ortho));
 }
 
 int main(int argc, char** argv)

--- a/tests/unit/casmutils/mush/twist.cpp
+++ b/tests/unit/casmutils/mush/twist.cpp
@@ -492,8 +492,8 @@ TEST_F(GrapheneTwistTest, ReportsSelfConsistency)
 
                     auto approx_moire_reconstruct = cu::xtal::make_superlattice(
                         r.approximate_tiling_unit, r.tiling_unit_supercell_matrix.cast<int>());
-                    cu::xtal::LatticeEquals_f equals(approx_moire_reconstruct, 1e-8);
-                    EXPECT_TRUE(equals(r.approximate_moire));
+                    cu::xtal::LatticeEquals_f equals(1e-8);
+                    EXPECT_TRUE(equals(approx_moire_reconstruct, r.approximate_moire));
                 }
             }
         }
@@ -514,7 +514,7 @@ TEST_F(GrapheneTwistTest, ReportsLayerConsistency)
 
             for (int i = 0; i < top_all_reports.size(); ++i)
             {
-                //should be ok to compare exact values
+                // should be ok to compare exact values
                 EXPECT_EQ(top_all_reports[i].approximate_moire.column_vector_matrix(),
                           bottom_all_reports[i].approximate_moire.column_vector_matrix());
                 EXPECT_EQ(top_all_reports[i].true_moire.column_vector_matrix(),
@@ -572,20 +572,20 @@ TEST_F(GrapheneTwistTest, MoireScelMagicDegreeTwist)
 
 TEST_F(GrapheneTwistTest, RepeatedExpansion)
 {
-    double angle=15.0;
+    double angle = 15.0;
     cu::mush::MoireApproximator mini_graph_moire(graphene_ptr->lattice(), angle);
 
-    auto all_cells=mini_graph_moire.all(ZONE::ALIGNED,ZONE::ALIGNED);
-    EXPECT_EQ(all_cells.size(),1);
+    auto all_cells = mini_graph_moire.all(ZONE::ALIGNED, ZONE::ALIGNED);
+    EXPECT_EQ(all_cells.size(), 1);
 
     mini_graph_moire.expand(1000);
-    all_cells=mini_graph_moire.all(ZONE::ALIGNED,ZONE::ALIGNED);
-    int cells_with_1000=all_cells.size();
+    all_cells = mini_graph_moire.all(ZONE::ALIGNED, ZONE::ALIGNED);
+    int cells_with_1000 = all_cells.size();
 
     mini_graph_moire.expand(1000);
-    all_cells=mini_graph_moire.all(ZONE::ALIGNED,ZONE::ALIGNED);
+    all_cells = mini_graph_moire.all(ZONE::ALIGNED, ZONE::ALIGNED);
 
-    EXPECT_EQ(cells_with_1000,all_cells.size());
+    EXPECT_EQ(cells_with_1000, all_cells.size());
 }
 
 int main(int argc, char** argv)

--- a/tests/unit/casmutils/xtal/coordinate.cpp
+++ b/tests/unit/casmutils/xtal/coordinate.cpp
@@ -125,6 +125,9 @@ TEST_F(CoordinateTest, CoordinateEquals)
 {
     CoordinateEquals_f coord0_equals(tol);
     EXPECT_TRUE(coord0_equals(*coord0_ptr, *coord1_ptr));
+
+    casmutils::UnaryComparator_f<CoordinateEquals_f> unary_coord_compare(*coord0_ptr, tol);
+    EXPECT_TRUE(unary_coord_compare(*coord1_ptr));
 }
 
 //

--- a/tests/unit/casmutils/xtal/coordinate.cpp
+++ b/tests/unit/casmutils/xtal/coordinate.cpp
@@ -123,8 +123,8 @@ TEST_F(CoordinateTest, PlusEqualOperator)
 
 TEST_F(CoordinateTest, CoordinateEquals)
 {
-    CoordinateEquals_f coord0_equals(*coord0_ptr, tol);
-    EXPECT_TRUE(coord0_equals(*coord1_ptr));
+    CoordinateEquals_f coord0_equals(tol);
+    EXPECT_TRUE(coord0_equals(*coord0_ptr, *coord1_ptr));
 }
 
 //

--- a/tests/unit/casmutils/xtal/lattice.cpp
+++ b/tests/unit/casmutils/xtal/lattice.cpp
@@ -124,9 +124,9 @@ TEST_F(LatticeTest, LatticeEquals)
     casmutils::xtal::Lattice fcc_with_distortion_lat(fcc_with_distortion_matrix);
     //  checks the ability to determine if two lattices
     // are equivalent within numerical tolerance
-    casmutils::xtal::LatticeEquals_f is_equal_to_fcc_lattice(*fcc_ptr, tol);
-    EXPECT_TRUE(is_equal_to_fcc_lattice(*fcc_copy_ptr));
-    EXPECT_FALSE(is_equal_to_fcc_lattice(fcc_with_distortion_lat));
+    casmutils::xtal::LatticeEquals_f is_equal_to_fcc_lattice(tol);
+    EXPECT_TRUE(is_equal_to_fcc_lattice(*fcc_ptr, *fcc_copy_ptr));
+    EXPECT_FALSE(is_equal_to_fcc_lattice(*fcc_ptr, fcc_with_distortion_lat));
 }
 
 TEST_F(LatticeTest, MakeNiggli)

--- a/tests/unit/casmutils/xtal/lattice.cpp
+++ b/tests/unit/casmutils/xtal/lattice.cpp
@@ -127,6 +127,10 @@ TEST_F(LatticeTest, LatticeEquals)
     casmutils::xtal::LatticeEquals_f is_equal_to_fcc_lattice(tol);
     EXPECT_TRUE(is_equal_to_fcc_lattice(*fcc_ptr, *fcc_copy_ptr));
     EXPECT_FALSE(is_equal_to_fcc_lattice(*fcc_ptr, fcc_with_distortion_lat));
+
+    casmutils::UnaryComparator_f<casmutils::xtal::LatticeEquals_f> unary_lattice_comparator(*fcc_ptr, tol);
+    EXPECT_TRUE(unary_lattice_comparator(*fcc_copy_ptr));
+    EXPECT_FALSE(unary_lattice_comparator(fcc_with_distortion_lat));
 }
 
 TEST_F(LatticeTest, MakeNiggli)
@@ -163,6 +167,9 @@ TEST_F(LatticeIsEquivalentTest, Identical)
 {
     casmutils::xtal::LatticeIsEquivalent_f exactly_equivalent(1e-8);
     EXPECT_TRUE(exactly_equivalent(*fcc_ptr, *fcc_ptr));
+
+    casmutils::UnaryComparator_f<casmutils::xtal::LatticeIsEquivalent_f> unary_lattice_comparator(*fcc_ptr, 1e-8);
+    EXPECT_TRUE(unary_lattice_comparator(*fcc_ptr));
 }
 
 TEST_F(LatticeIsEquivalentTest, PermutedVectors)

--- a/tests/unit/casmutils/xtal/site.cpp
+++ b/tests/unit/casmutils/xtal/site.cpp
@@ -61,9 +61,9 @@ TEST_F(SiteTest, SiteEquals)
 {
     // checks the ability to determine the equality of sites using Functor
     double tol = 1e-5;
-    casmutils::xtal::SiteEquals_f is_equal_to_lithium_site(*lithium_site_ptr, tol);
-    EXPECT_TRUE(is_equal_to_lithium_site(*lithium_site_ptr));
-    EXPECT_FALSE(is_equal_to_lithium_site(*nickel_site_ptr));
+    casmutils::xtal::SiteEquals_f is_equal_to_lithium_site(tol);
+    EXPECT_TRUE(is_equal_to_lithium_site(*lithium_site_ptr, *lithium_site_ptr));
+    EXPECT_FALSE(is_equal_to_lithium_site(*lithium_site_ptr, *nickel_site_ptr));
 };
 
 int main(int argc, char** argv)

--- a/tests/unit/casmutils/xtal/site.cpp
+++ b/tests/unit/casmutils/xtal/site.cpp
@@ -1,4 +1,5 @@
 // these are required for test construction
+#include <casmutils/misc.hpp>
 #include <casmutils/xtal/coordinate.hpp>
 #include <casmutils/xtal/lattice.hpp>
 #include <gtest/gtest.h>
@@ -64,6 +65,10 @@ TEST_F(SiteTest, SiteEquals)
     casmutils::xtal::SiteEquals_f is_equal_to_lithium_site(tol);
     EXPECT_TRUE(is_equal_to_lithium_site(*lithium_site_ptr, *lithium_site_ptr));
     EXPECT_FALSE(is_equal_to_lithium_site(*lithium_site_ptr, *nickel_site_ptr));
+
+    casmutils::UnaryComparator_f<casmutils::xtal::SiteEquals_f> unary_site_comparator(*lithium_site_ptr, tol);
+    EXPECT_TRUE(unary_site_comparator(*lithium_site_ptr));
+    EXPECT_FALSE(unary_site_comparator(*nickel_site_ptr));
 };
 
 int main(int argc, char** argv)

--- a/tests/unit/casmutils/xtal/structure_tools.cpp
+++ b/tests/unit/casmutils/xtal/structure_tools.cpp
@@ -96,9 +96,11 @@ protected:
         for (int i = 0; i < ref_basis.size(); i++)
         {
             // construct an equals predicate
-            casmutils::xtal::SiteEquals_f is_equal_to_site_i(ref_basis[i], tol);
+            casmutils::xtal::SiteEquals_f is_equal_to_site_i(tol);
             // search in constructed basis for site equivalent to conventional fcc site i
-            if (std::find_if(test_basis.begin(), test_basis.end(), is_equal_to_site_i) == test_basis.end())
+            if (std::find_if(test_basis.begin(), test_basis.end(), [&](const casmutils::xtal::Site& test_basis) {
+                    return is_equal_to_site_i(test_basis, ref_basis[i]);
+                }) == test_basis.end())
             {
                 // if hit end iterator return false
                 return false;


### PR DESCRIPTION
- Switched the `CoordinateEquals_f`, `SiteEquals_f`, `LatticeEquals_f` comparators from unary to binary.
- Added a templated `UnaryComparator_f` class which converts a given BinaryComparator_f to UnaryComparator_f for uses in std::find_if etc.
- Added tests for `UnaryComparator_f` class
- Made changes to tests and python module accordingly.