### PR TITLE
Bug fix for picking Brillouin zone for twisted structures

### DIFF
--- a/lib/casmutils/mush/twist.cxx
+++ b/lib/casmutils/mush/twist.cxx
@@ -249,11 +249,6 @@ xtal::Lattice make_prismatic_lattice(const xtal::Lattice& lat)
 DeformationReport::DeformationReport(const Eigen::Matrix3d& _deformation) : deformation(_deformation)
 {
     std::tie(rotation, strain) = xtal::polar_decomposition(deformation);
-    //We will not decompose as F=RU, but F=VR
-    //The relationship exists V=R*U*R.T
-    //https://en.wikipedia.org/wiki/Finite_strain_theory#Polar_decomposition_of_the_deformation_gradient_tensor
-    strain=rotation*strain*rotation.transpose();
-
     this->rotation_angle = std::atan2(rotation(1, 0), rotation(0, 0)) * 180.0 / M_PI;
 
     Eigen::Matrix3d E = strain - Eigen::Matrix3d::Identity();
@@ -496,7 +491,7 @@ MoireApproximator::MoireApproximator(const xtal::Lattice& input_lat, double degr
     this->moire_unit_approximants.try_emplace(
         LATTICE::ALIGNED, moire.aligned_moire_lattice, moire.aligned_lattice, moire.rotated_lattice);
     this->moire_unit_approximants.try_emplace(
-        LATTICE::ROTATED, moire.aligned_moire_lattice, moire.rotated_lattice, moire.rotated_lattice);
+        LATTICE::ROTATED, moire.rotated_moire_lattice, moire.aligned_lattice, moire.rotated_lattice);
 
     // Go ahead and enumerate the smallest Moire possible.
     // Subsequent enumeration of supercells counts on this.

--- a/lib/casmutils/mush/twist.cxx
+++ b/lib/casmutils/mush/twist.cxx
@@ -249,6 +249,11 @@ xtal::Lattice make_prismatic_lattice(const xtal::Lattice& lat)
 DeformationReport::DeformationReport(const Eigen::Matrix3d& _deformation) : deformation(_deformation)
 {
     std::tie(rotation, strain) = xtal::polar_decomposition(deformation);
+    //We will not decompose as F=RU, but F=VR
+    //The relationship exists V=R*U*R.T
+    //https://en.wikipedia.org/wiki/Finite_strain_theory#Polar_decomposition_of_the_deformation_gradient_tensor
+    strain=rotation*strain*rotation.transpose();
+
     this->rotation_angle = std::atan2(rotation(1, 0), rotation(0, 0)) * 180.0 / M_PI;
 
     Eigen::Matrix3d E = strain - Eigen::Matrix3d::Identity();

--- a/tests/unit/casmutils/mush/twist.cpp
+++ b/tests/unit/casmutils/mush/twist.cpp
@@ -477,7 +477,7 @@ TEST_F(GrapheneTwistTest, ReportsSelfConsistency)
     {
         for (LAT layer : {LAT::ALIGNED, LAT::ROTATED})
         {
-            for (double angle = 1.0; angle < 55.0; angle += 1.5)
+            for (double angle = 1.0; angle < 55.0; angle += 2.1)
             {
                 cu::mush::MoireApproximator graphene_approximator(graphene_ptr->lattice(), angle, 500);
                 auto all_reports = graphene_approximator.all(bz, layer);
@@ -568,6 +568,20 @@ TEST_F(GrapheneTwistTest, MoireScelMagicDegreeTwist)
             }
         }
     }
+}
+
+TEST_F(GrapheneTwistTest, DeformationReportTrivial)
+{
+    const auto I = Eigen::Matrix3d::Identity();
+    cu::mush::DeformationReport report(I);
+    
+    const auto&F = report.deformation;
+    const auto&R = report.rotation;
+    const auto&V = report.strain;
+
+    EXPECT_TRUE(almost_zero(F - I));
+    EXPECT_TRUE(almost_zero(R - I));
+    EXPECT_TRUE(almost_zero(V - I));
 }
 
 TEST_F(GrapheneTwistTest, RepeatedExpansion)


### PR DESCRIPTION
Picking rotated Brillouin zones was resulting in zero reported strain because the same structure was being used for the top and bottom layers.

Also speeds up the tests a bit by skipping a bunch of test angles, and adds one new test.